### PR TITLE
fix: Set max attstattarget for edge label's start, end column

### DIFF
--- a/src/backend/commands/graphcmds.c
+++ b/src/backend/commands/graphcmds.c
@@ -44,6 +44,7 @@
 static ObjectAddress DefineLabel(CreateStmt *stmt, char labkind);
 static void GetSuperOids(List *supers, char labkind, List **supOids);
 static void AgInheritanceDependancy(Oid laboid, List *supers);
+static void SetMaxStatisticsTarget(Oid laboid);
 
 /* See ProcessUtilitySlow() case T_CreateSchemaStmt */
 void
@@ -207,6 +208,9 @@ DefineLabel(CreateStmt *stmt, char labkind)
 
 	CommandCounterIncrement();
 
+	if (labkind == LABEL_KIND_EDGE)
+		SetMaxStatisticsTarget(reladdr.objectId);
+
 	/* parse and validate reloptions for the toast table */
 	toast_options = transformRelOptions((Datum) 0, stmt->options, "toast",
 										validnsps, true, false);
@@ -241,6 +245,58 @@ DefineLabel(CreateStmt *stmt, char labkind)
 	recordDependencyOn(&reladdr, &labaddr, DEPENDENCY_INTERNAL);
 
 	return labaddr;
+}
+
+/*
+ * reference : ATExecSetStatistics()
+ */
+static void
+SetMaxStatisticsTarget(Oid laboid)
+{
+	Relation			attrelation;
+	HeapTuple			tuple;
+	Form_pg_attribute	attrtuple;
+	int					maxtarget = 10000;
+
+	attrelation = heap_open(AttributeRelationId, RowExclusiveLock);
+
+	/* start column */
+	tuple = SearchSysCacheCopyAttName(laboid, AG_START_ID);
+
+	if (!HeapTupleIsValid(tuple))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_COLUMN),
+				 errmsg("graph label must have start column")));
+
+	attrtuple = (Form_pg_attribute) GETSTRUCT(tuple);
+
+	attrtuple->attstattarget = maxtarget;
+
+	simple_heap_update(attrelation, &tuple->t_self, tuple);
+
+	CatalogUpdateIndexes(attrelation, tuple);
+
+	heap_freetuple(tuple);
+
+	/* end column */
+	tuple = SearchSysCacheCopyAttName(laboid, AG_END_ID);
+
+	if (!HeapTupleIsValid(tuple))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_COLUMN),
+				 errmsg("graph label must have end column")));
+
+	attrtuple = (Form_pg_attribute) GETSTRUCT(tuple);
+
+	attrtuple->attstattarget = maxtarget;
+
+	simple_heap_update(attrelation, &tuple->t_self, tuple);
+
+	CatalogUpdateIndexes(attrelation, tuple);
+
+	heap_freetuple(tuple);
+
+	heap_close(attrelation, RowExclusiveLock);
 }
 
 static void

--- a/src/test/regress/expected/cypher_ddl.out
+++ b/src/test/regress/expected/cypher_ddl.out
@@ -190,6 +190,23 @@ REINDEX VLABEL g.vdi;
 ERROR:  syntax error at or near "."
 LINE 1: REINDEX VLABEL g.vdi;
                         ^
+-- check default attstattarget of edge label
+SELECT attname, attstattarget FROM pg_attribute
+WHERE attrelid = ( SELECT oid FROM pg_class WHERE relname = 'e1');
+  attname   | attstattarget 
+------------+---------------
+ tableoid   |             0
+ cmax       |             0
+ xmax       |             0
+ cmin       |             0
+ xmin       |             0
+ ctid       |             0
+ id         |            -1
+ start      |         10000
+ end        |         10000
+ properties |            -1
+(10 rows)
+
 --
 -- COMMENT and \dG commands
 --

--- a/src/test/regress/sql/cypher_ddl.sql
+++ b/src/test/regress/sql/cypher_ddl.sql
@@ -102,6 +102,10 @@ REINDEX VLABEL vdi;
 REINDEX ELABEL vdi;
 REINDEX VLABEL g.vdi;
 
+-- check default attstattarget of edge label
+SELECT attname, attstattarget FROM pg_attribute
+WHERE attrelid = ( SELECT oid FROM pg_class WHERE relname = 'e1');
+
 --
 -- COMMENT and \dG commands
 --


### PR DESCRIPTION
Change default value of attstattarget from '-1' to '10000'
when the column is 'start' or 'end' of edge label.