### PR TITLE
fix: Crash occur when creating graph elemnts

### DIFF
--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -129,6 +129,11 @@ CREATE ()-[:repo]->();
 ERROR:  edge label "repo" does not exist
 LINE 1: CREATE ()-[:repo]->();
                     ^
+CREATE (=null::jsonb)-[:lib =null::jsonb]->();
+CREATE TABLE t1 (prop jsonb);
+CREATE (=(SELECT prop FROM t1))-[:lib =(SELECT prop FROM t1)]->();
+MATCH (a) WHERE a.name IS NULL DETACH DELETE a;
+DROP TABLE t1;
 --
 -- MATCH
 --

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -67,6 +67,12 @@ CREATE a=(), a=();
 CREATE (:lib);
 CREATE ()-[:repo]->();
 
+CREATE (=null::jsonb)-[:lib =null::jsonb]->();
+CREATE TABLE t1 (prop jsonb);
+CREATE (=(SELECT prop FROM t1))-[:lib =(SELECT prop FROM t1)]->();
+
+MATCH (a) WHERE a.name IS NULL DETACH DELETE a;
+DROP TABLE t1;
 --
 -- MATCH
 --


### PR DESCRIPTION
* If the property has a null json value, it is treated as an empty json.