### PR TITLE
chore: Stop enabling some extensions by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ env:
 
 before_script:
  - ./configure --prefix="$(pwd)"
+ - make install > /dev/null
  - export PATH="$(pwd)"/bin:$PATH
- - make install-world > /dev/null
  - initdb
  - ag_ctl start -w
 

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -1327,13 +1327,13 @@ setup_config(void)
 #ifdef USE_PG_STATSINFO
 	conflines = replace_token(conflines,
 							"#shared_preload_libraries = ''",
-							"shared_preload_libraries = "
+							"#shared_preload_libraries = "
 									"'pg_stat_statements,pg_statsinfo,"
 									"pg_hint_plan,hll'");
 #else
 	conflines = replace_token(conflines,
 							"#shared_preload_libraries = ''",
-							"shared_preload_libraries = "
+							"#shared_preload_libraries = "
 									"'pg_stat_statements,pg_hint_plan,hll'");
 #endif
 


### PR DESCRIPTION
pg_stat_statements, pg_statsinfo, pg_hint_plan, and postgresql-hll are
now disabled by default.