### PR TITLE
chore: Match messages printed by CLIs with AgensGraph

### DIFF
--- a/src/bin/agens/command.c
+++ b/src/bin/agens/command.c
@@ -2069,7 +2069,8 @@ connection_warnings(bool in_startup)
 		}
 		/* For version match, only print psql banner on startup. */
 		else if (in_startup)
-			printf("%s (%s)\n", pset.progname, AG_VERSION);
+			printf("%s (AgensGraph %s, based on PostgreSQL %s)\n",
+				   pset.progname, AG_VERSION, PG_VERSION);
 
 		if (pset.sversion / 100 > client_ver / 100)
 			printf(_("WARNING: %s major version %s, server major version %s.\n"

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -2791,7 +2791,6 @@ usage(const char *progname)
 	printf(_("  -?, --help                show this help, then exit\n"));
 	printf(_("\nIf the data directory is not specified, the environment variable PGDATA\n"
 			 "is used.\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
 }
 
 static void
@@ -3716,7 +3715,7 @@ main(int argc, char *argv[])
 	get_parent_directory(bin_dir);
 
 	printf(_("\nSuccess. You can now start the database server using:\n\n"
-			 "    %s%s%spg_ctl%s -D %s%s%s -l logfile start\n\n"),
+			 "    %s%s%sag_ctl%s -D %s%s%s -l logfile start\n\n"),
 	   QUOTE_PATH, bin_dir, (strlen(bin_dir) > 0) ? DIR_SEP : "", QUOTE_PATH,
 		   QUOTE_PATH, pgdata_native, QUOTE_PATH);
 

--- a/src/bin/scripts/createdb.c
+++ b/src/bin/scripts/createdb.c
@@ -248,7 +248,7 @@ main(int argc, char *argv[])
 static void
 help(const char *progname)
 {
-	printf(_("%s creates a PostgreSQL database.\n\n"), progname);
+	printf(_("%s creates an AgensGraph database.\n\n"), progname);
 	printf(_("Usage:\n"));
 	printf(_("  %s [OPTION]... [DBNAME] [DESCRIPTION]\n"), progname);
 	printf(_("\nOptions:\n"));
@@ -270,5 +270,4 @@ help(const char *progname)
 	printf(_("  -W, --password               force password prompt\n"));
 	printf(_("  --maintenance-db=DBNAME      alternate maintenance database\n"));
 	printf(_("\nBy default, a database with the same name as the current user is created.\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
 }

--- a/src/bin/scripts/createlang.c
+++ b/src/bin/scripts/createlang.c
@@ -232,7 +232,7 @@ main(int argc, char *argv[])
 static void
 help(const char *progname)
 {
-	printf(_("%s installs a procedural language into a PostgreSQL database.\n\n"), progname);
+	printf(_("%s installs a procedural language into an AgensGraph database.\n\n"), progname);
 	printf(_("Usage:\n"));
 	printf(_("  %s [OPTION]... LANGNAME [DBNAME]\n"), progname);
 	printf(_("\nOptions:\n"));
@@ -247,5 +247,4 @@ help(const char *progname)
 	printf(_("  -U, --username=USERNAME   user name to connect as\n"));
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
 }

--- a/src/bin/scripts/createuser.c
+++ b/src/bin/scripts/createuser.c
@@ -345,7 +345,7 @@ main(int argc, char *argv[])
 static void
 help(const char *progname)
 {
-	printf(_("%s creates a new PostgreSQL role.\n\n"), progname);
+	printf(_("%s creates a new AgensGraph role.\n\n"), progname);
 	printf(_("Usage:\n"));
 	printf(_("  %s [OPTION]... [ROLENAME]\n"), progname);
 	printf(_("\nOptions:\n"));
@@ -378,5 +378,4 @@ help(const char *progname)
 	printf(_("  -U, --username=USERNAME   user name to connect as (not the one to create)\n"));
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
 }

--- a/src/bin/scripts/dropdb.c
+++ b/src/bin/scripts/dropdb.c
@@ -151,7 +151,7 @@ main(int argc, char *argv[])
 static void
 help(const char *progname)
 {
-	printf(_("%s removes a PostgreSQL database.\n\n"), progname);
+	printf(_("%s removes an AgensGraph database.\n\n"), progname);
 	printf(_("Usage:\n"));
 	printf(_("  %s [OPTION]... DBNAME\n"), progname);
 	printf(_("\nOptions:\n"));
@@ -167,5 +167,4 @@ help(const char *progname)
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
 	printf(_("  --maintenance-db=DBNAME   alternate maintenance database\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
 }

--- a/src/bin/scripts/droplang.c
+++ b/src/bin/scripts/droplang.c
@@ -248,5 +248,4 @@ help(const char *progname)
 	printf(_("  -U, --username=USERNAME   user name to connect as\n"));
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
 }

--- a/src/bin/scripts/dropuser.c
+++ b/src/bin/scripts/dropuser.c
@@ -152,7 +152,7 @@ main(int argc, char *argv[])
 static void
 help(const char *progname)
 {
-	printf(_("%s removes a PostgreSQL role.\n\n"), progname);
+	printf(_("%s removes an AgensGraph role.\n\n"), progname);
 	printf(_("Usage:\n"));
 	printf(_("  %s [OPTION]... [ROLENAME]\n"), progname);
 	printf(_("\nOptions:\n"));
@@ -168,5 +168,4 @@ help(const char *progname)
 	printf(_("  -U, --username=USERNAME   user name to connect as (not the one to drop)\n"));
 	printf(_("  -w, --no-password         never prompt for password\n"));
 	printf(_("  -W, --password            force password prompt\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
 }

--- a/src/bin/scripts/po/ko.po
+++ b/src/bin/scripts/po/ko.po
@@ -336,10 +336,10 @@ msgstr "%s: 코멘트 추가하기 실패 (데이터베이스는 만들어졌음
 #: createdb.c:251
 #, c-format
 msgid ""
-"%s creates a PostgreSQL database.\n"
+"%s creates an AgensGraph database.\n"
 "\n"
 msgstr ""
-"%s 프로그램은 PostgreSQL 데이터베이스를 만듭니다.\n"
+"%s 프로그램은 AgensGraph 데이터베이스를 만듭니다.\n"
 "\n"
 
 #: createdb.c:253
@@ -479,10 +479,10 @@ msgstr "%s: 언어 설치 실패: %s"
 #: createlang.c:235
 #, c-format
 msgid ""
-"%s installs a procedural language into a PostgreSQL database.\n"
+"%s installs a procedural language into an AgensGraph database.\n"
 "\n"
 msgstr ""
-"%s 프로그램은 PostgreSQL 데이터베이스에 프로시쥬얼 언어를 설치합니다.\n"
+"%s 프로그램은 AgensGraph 데이터베이스에 프로시쥬얼 언어를 설치합니다.\n"
 "\n"
 
 #: createlang.c:237 droplang.c:238
@@ -543,10 +543,10 @@ msgstr "%s: 새 롤 만들기 실패: %s"
 #: createuser.c:348
 #, c-format
 msgid ""
-"%s creates a new PostgreSQL role.\n"
+"%s creates a new AgensGraph role.\n"
 "\n"
 msgstr ""
-"%s 프로그램은 PostgreSQL 롤을 만듭니다.\n"
+"%s 프로그램은 AgensGraph 롤을 만듭니다.\n"
 "\n"
 
 #: createuser.c:350 dropuser.c:157
@@ -685,10 +685,10 @@ msgstr "%s: 데이터베이스 삭제 실패: %s"
 #: dropdb.c:154
 #, c-format
 msgid ""
-"%s removes a PostgreSQL database.\n"
+"%s removes an AgensGraph database.\n"
 "\n"
 msgstr ""
-"%s 프로그램은 PostgreSQL 데이터베이스를 삭제합니다.\n"
+"%s 프로그램은 AgensGraph 데이터베이스를 삭제합니다.\n"
 "\n"
 
 #: dropdb.c:156
@@ -755,10 +755,10 @@ msgstr "%s: \"%s\" 롤 삭제 실패: %s"
 #: dropuser.c:155
 #, c-format
 msgid ""
-"%s removes a PostgreSQL role.\n"
+"%s removes an AgensGraph role.\n"
 "\n"
 msgstr ""
-"%s 프로그램은 PostgreSQL 롤을 삭제합니다.\n"
+"%s 프로그램은 AgensGraph 롤을 삭제합니다.\n"
 "\n"
 
 #: dropuser.c:160
@@ -962,10 +962,10 @@ msgstr "%s: 시스템 카탈로그 재색인 작업 실패: %s"
 #: reindexdb.c:400
 #, c-format
 msgid ""
-"%s reindexes a PostgreSQL database.\n"
+"%s reindexes an AgensGraph database.\n"
 "\n"
 msgstr ""
-"%s 프로그램은 PostgreSQL 데이터베이스 재색인 작업을 합니다.\n"
+"%s 프로그램은 AgensGraph 데이터베이스 재색인 작업을 합니다.\n"
 "\n"
 
 #: reindexdb.c:404
@@ -1074,10 +1074,10 @@ msgstr "%s: 잘못된 소켓: %s"
 #: vacuumdb.c:941
 #, c-format
 msgid ""
-"%s cleans and analyzes a PostgreSQL database.\n"
+"%s cleans and analyzes an AgensGraph database.\n"
 "\n"
 msgstr ""
-"%s 프로그램은 PostgreSQL 데이터베이스 자료 정리 및\n"
+"%s 프로그램은 AgensGraph 데이터베이스 자료 정리 및\n"
 "퀴리 최적화기의 참고 자료를 갱신합니다.\n"
 "\n"
 

--- a/src/bin/scripts/reindexdb.c
+++ b/src/bin/scripts/reindexdb.c
@@ -397,7 +397,7 @@ reindex_system_catalogs(const char *dbname, const char *host, const char *port,
 static void
 help(const char *progname)
 {
-	printf(_("%s reindexes a PostgreSQL database.\n\n"), progname);
+	printf(_("%s reindexes an AgensGraph database.\n\n"), progname);
 	printf(_("Usage:\n"));
 	printf(_("  %s [OPTION]... [DBNAME]\n"), progname);
 	printf(_("\nOptions:\n"));
@@ -420,5 +420,4 @@ help(const char *progname)
 	printf(_("  -W, --password            force password prompt\n"));
 	printf(_("  --maintenance-db=DBNAME   alternate maintenance database\n"));
 	printf(_("\nRead the description of the SQL command REINDEX for details.\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
 }

--- a/src/bin/scripts/vacuumdb.c
+++ b/src/bin/scripts/vacuumdb.c
@@ -942,7 +942,7 @@ init_slot(ParallelSlot *slot, PGconn *conn, const char *progname)
 static void
 help(const char *progname)
 {
-	printf(_("%s cleans and analyzes a PostgreSQL database.\n\n"), progname);
+	printf(_("%s cleans and analyzes an AgensGraph database.\n\n"), progname);
 	printf(_("Usage:\n"));
 	printf(_("  %s [OPTION]... [DBNAME]\n"), progname);
 	printf(_("\nOptions:\n"));
@@ -969,5 +969,4 @@ help(const char *progname)
 	printf(_("  -W, --password            force password prompt\n"));
 	printf(_("  --maintenance-db=DBNAME   alternate maintenance database\n"));
 	printf(_("\nRead the description of the SQL command VACUUM for details.\n"));
-	printf(_("\nReport bugs to <pgsql-bugs@postgresql.org>.\n"));
 }


### PR DESCRIPTION
* Change "PostgreSQL" in help messages of `createdb`, `createlang`,
  `createuser`, `dropdb`, `dropuser`, `reindexdb`, `vacuumdb` to
  "AgensGraph"
* Remove "Report bugs to ..." in help messages of above tools,
  `initdb`, and `droplang`.
* Print detailed version information when `agens` prints out greetings