### PR TITLE
chore: Set `random_page_cost` parameter to 0.005 by default

### DIFF
--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -292,7 +292,7 @@
 # - Planner Cost Constants -
 
 #seq_page_cost = 1.0			# measured on an arbitrary scale
-#random_page_cost = 4.0			# same scale as above
+random_page_cost = 0.005			# same scale as above
 #cpu_tuple_cost = 0.01			# same scale as above
 #cpu_index_tuple_cost = 0.005		# same scale as above
 #cpu_operator_cost = 0.0025		# same scale as above


### PR DESCRIPTION
For better execution plans of graph queries, the value is changed.
The previous default value was 4.0.