### PR TITLE
fix: ERROR when `CREATE GRAPH IF NOT EXISTS`

### DIFF
--- a/src/backend/commands/graphcmds.c
+++ b/src/backend/commands/graphcmds.c
@@ -50,10 +50,14 @@ static void SetMaxStatisticsTarget(Oid laboid);
 void
 CreateGraphCommand(CreateGraphStmt *stmt, const char *queryString)
 {
+	Oid			graphid;
 	List	   *parsetree_list;
 	ListCell   *parsetree_item;
 
-	GraphCreate(stmt, queryString);
+	graphid = GraphCreate(stmt, queryString);
+	if (!OidIsValid(graphid))
+		return;
+
 	CommandCounterIncrement();
 
 	parsetree_list = transformCreateGraphStmt(stmt);


### PR DESCRIPTION
`CREATE GRAPH IF NOT EXISTS` returns ERROR when the given graph name
already exists. It should not return error.

Closes #192