### PR TITLE
feat: Implement map literal

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2088,6 +2088,17 @@ _copyEdgeRefRows(const EdgeRefRows *from)
 	return newnode;
 }
 
+static CypherMapExpr *
+_copyCypherMapExpr(const CypherMapExpr *from)
+{
+	CypherMapExpr *newnode = makeNode(CypherMapExpr);
+
+	COPY_NODE_FIELD(keyvals);
+	COPY_LOCATION_FIELD(location);
+
+	return newnode;
+}
+
 /* ****************************************************************
  *						relation.h copy functions
  *
@@ -5074,6 +5085,9 @@ copyObject(const void *from)
 			break;
 		case T_EdgeRefRows:
 			retval = _copyEdgeRefRows(from);
+			break;
+		case T_CypherMapExpr:
+			retval = _copyCypherMapExpr(from);
 			break;
 
 			/*

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -800,6 +800,15 @@ _equalEdgeRefRows(const EdgeRefRows *a, const EdgeRefRows *b)
 	return true;
 }
 
+static bool
+_equalCypherMapExpr(const CypherMapExpr *a, const CypherMapExpr *b)
+{
+	COMPARE_NODE_FIELD(keyvals);
+	COMPARE_LOCATION_FIELD(location);
+
+	return true;
+}
+
 /*
  * Stuff from relation.h
  */
@@ -3239,6 +3248,9 @@ equal(const void *a, const void *b)
 			break;
 		case T_EdgeRefRows:
 			retval = _equalEdgeRefRows(a, b);
+			break;
+		case T_CypherMapExpr:
+			retval = _equalCypherMapExpr(a, b);
 			break;
 
 			/*

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1664,6 +1664,15 @@ _outEdgeRefRows(StringInfo str, const EdgeRefRows *node)
 	WRITE_NODE_FIELD(arg);
 }
 
+static void
+_outCypherMapExpr(StringInfo str, const CypherMapExpr *node)
+{
+	WRITE_NODE_TYPE("CYPHERMAPEXPR");
+
+	WRITE_NODE_FIELD(keyvals);
+	WRITE_LOCATION_FIELD(location);
+}
+
 
 /*****************************************************************************
  *
@@ -3987,6 +3996,9 @@ outNode(StringInfo str, const void *obj)
 				break;
 			case T_EdgeRefRows:
 				_outEdgeRefRows(str, obj);
+				break;
+			case T_CypherMapExpr:
+				_outCypherMapExpr(str, obj);
 				break;
 			case T_Path:
 				_outPath(str, obj);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2405,6 +2405,17 @@ _readEdgeRefRows(void)
 	READ_DONE();
 }
 
+static CypherMapExpr *
+_readCypherMapExpr(void)
+{
+	READ_LOCALS(CypherMapExpr);
+
+	READ_NODE_FIELD(keyvals);
+	READ_LOCATION_FIELD(location);
+
+	READ_DONE();
+}
+
 /*
  * parseNodeString
  *
@@ -2655,6 +2666,8 @@ parseNodeString(void)
 		return_value = _readEdgeRefRow();
 	else if (MATCH("EDGEREFROWS", 11))
 		return_value = _readEdgeRefRows();
+	else if (MATCH("CYPHERMAPEXPR", 13))
+		return_value = _readCypherMapExpr();
 	else
 	{
 		elog(ERROR, "badly formatted node string \"%.32s\"...", token);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -15677,10 +15677,11 @@ cypher_expr_literal:
 cypher_expr_map:
 			'{' cypher_expr_map_keyvals '}'
 				{
-					CypherMap  *n;
+					CypherMapExpr  *n;
 
-					n = makeNode(CypherMap);
+					n = makeNode(CypherMapExpr);
 					n->keyvals = $2;
+					n->location = @1;
 					$$ = (Node *) n;
 				}
 		;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1051,6 +1051,12 @@ typedef struct EdgeRefRowsState
 	ArrayMetaState iter_meta;
 } EdgeRefRowsState;
 
+typedef struct CypherMapExprState
+{
+	ExprState	xprstate;
+	List	   *keyvals;
+} CypherMapExprState;
+
 /* ----------------------------------------------------------------
  *				 Executor State Trees
  *

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -192,6 +192,7 @@ typedef enum NodeTag
 	T_EdgeRefProp,
 	T_EdgeRefRow,
 	T_EdgeRefRows,
+	T_CypherMapExpr,
 
 	/*
 	 * TAGS FOR EXPRESSION STATE NODES (execnodes.h)
@@ -230,6 +231,7 @@ typedef enum NodeTag
 	T_EdgeRefPropState,
 	T_EdgeRefRowState,
 	T_EdgeRefRowsState,
+	T_CypherMapExprState,
 
 	/*
 	 * TAGS FOR PLANNER NODES (relation.h)
@@ -495,7 +497,6 @@ typedef enum NodeTag
 	T_CypherRel,
 	T_CypherName,
 	T_CypherSetProp,
-	T_CypherMap,
 	T_CypherList,
 
 	/*

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3413,12 +3413,6 @@ typedef struct CypherSetProp
  * Cypher Query Language
  */
 
-typedef struct CypherMap
-{
-	NodeTag		type;
-	List	   *keyvals;
-} CypherMap;
-
 typedef struct CypherList
 {
 	NodeTag		type;

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -1448,4 +1448,15 @@ typedef struct EdgeRefRows
 	Expr	   *arg;
 } EdgeRefRows;
 
+/*
+ * Cypher Query Language
+ */
+
+typedef struct CypherMapExpr
+{
+	Expr		xpr;
+	List	   *keyvals;
+	int			location;
+} CypherMapExpr;
+
 #endif   /* PRIMNODES_H */


### PR DESCRIPTION
If all property values in a map literal are constant, the map literal
will be pre-evaluated to make it a single constant.

Here is an example of map literal.

```
{
    i: 7,
    n: 7.0,
    s: '"Hello\nAgensGraph\"',
    t: true,
    f: false,
    '0': null,
    '\n': 'AS-IS',
    o: {
        v: 'bitnine',
        o: {
            v: 'bitnine'
        }
    }
}
```

And the following is the evaluated result. Properties that have null as
their value are omitted.

```
{
    "f": false,
    "i": 7,
    "n": 7.0,
    "o": {
        "o": {
            "v": "bitnine"
        },
        "v": "bitnine"
    },
    "s": "\"Hello\nAgensGraph\"",
    "t": true,
    "\\n": "AS-IS"
}
```