### PR TITLE
feat: Implement comparison and boolean operators

### DIFF
--- a/src/include/catalog/pg_cast.h
+++ b/src/include/catalog/pg_cast.h
@@ -382,4 +382,8 @@ DATA(insert ( 3802	114    0 a i ));
 DATA(insert ( 7012 3802 7019 i f ));
 DATA(insert ( 7022 3802 7029 i f ));
 
+/* implicit coercions between jsonb and bool */
+DATA(insert ( 3802   16 7191 i f ));
+DATA(insert (   16 3802 7192 i f ));
+
 #endif   /* PG_CAST_H */

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5457,6 +5457,9 @@ DATA(insert OID = 7183 ( jsonb_mod		PGNSP PGUID 12 1 0 0 0 f f f f t f i s 2 0 3
 DATA(insert OID = 7185 ( jsonb_pow		PGNSP PGUID 12 1 0 0 0 f f f f t f i s 2 0 3802 "3802 3802" _null_ _null_ _null_ _null_ _null_ jsonb_pow _null_ _null_ _null_ ));
 DATA(insert OID = 7187 ( jsonb_uplus	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 3802 "3802" _null_ _null_ _null_ _null_ _null_ jsonb_uplus _null_ _null_ _null_ ));
 DATA(insert OID = 7189 ( jsonb_uminus	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 3802 "3802" _null_ _null_ _null_ _null_ _null_ jsonb_uminus _null_ _null_ _null_ ));
+/* Cypher expressions - coercions between jsonb and bool */
+DATA(insert OID = 7191 ( bool		PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 16 "3802" _null_ _null_ _null_ _null_ _null_ jsonb_bool _null_ _null_ _null_ ));
+DATA(insert OID = 7192 ( jsonb		PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 3802 "16" _null_ _null_ _null_ _null_ _null_ bool_jsonb _null_ _null_ _null_ ));
 
 /*
  * Symbolic values for provolatile column: these indicate whether the result

--- a/src/include/utils/cypher_ops.h
+++ b/src/include/utils/cypher_ops.h
@@ -22,4 +22,8 @@ extern Datum jsonb_pow(PG_FUNCTION_ARGS);
 extern Datum jsonb_uplus(PG_FUNCTION_ARGS);
 extern Datum jsonb_uminus(PG_FUNCTION_ARGS);
 
+/* coercions between jsonb and bool */
+extern Datum jsonb_bool(PG_FUNCTION_ARGS);
+extern Datum bool_jsonb(PG_FUNCTION_ARGS);
+
 #endif	/* CYPHER_OPS_H */


### PR DESCRIPTION
The implementation of comparison operators (=, <>, <, >, <=, >=) uses
existing `jsonb` comparison functions. This has pros and cons. It
allows optimizer to make use of indexes. And the implementation is
relatively easy. However, those functions return `bool` value. It means
if users want to use the value as a literal value, type conversion from
`boot` to `jsonb` is required. So, implicit type conversion between
`jsonb` and `bool` is introduced.

The implementation of boolean operators (OR, AND, NOT) also uses
existing boolean expression implementation. It has similar pros and
cons to that of comparison operators.