### PR TITLE
feat: Implement property access

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2099,6 +2099,17 @@ _copyCypherMapExpr(const CypherMapExpr *from)
 	return newnode;
 }
 
+static CypherAccessExpr *
+_copyCypherAccessExpr(const CypherAccessExpr *from)
+{
+	CypherAccessExpr *newnode = makeNode(CypherAccessExpr);
+
+	COPY_NODE_FIELD(arg);
+	COPY_NODE_FIELD(path);
+
+	return newnode;
+}
+
 /* ****************************************************************
  *						relation.h copy functions
  *
@@ -5088,6 +5099,9 @@ copyObject(const void *from)
 			break;
 		case T_CypherMapExpr:
 			retval = _copyCypherMapExpr(from);
+			break;
+		case T_CypherAccessExpr:
+			retval = _copyCypherAccessExpr(from);
 			break;
 
 			/*

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -809,6 +809,15 @@ _equalCypherMapExpr(const CypherMapExpr *a, const CypherMapExpr *b)
 	return true;
 }
 
+static bool
+_equalCypherAccessExpr(const CypherAccessExpr *a, const CypherAccessExpr *b)
+{
+	COMPARE_NODE_FIELD(arg);
+	COMPARE_NODE_FIELD(path);
+
+	return true;
+}
+
 /*
  * Stuff from relation.h
  */
@@ -3251,6 +3260,9 @@ equal(const void *a, const void *b)
 			break;
 		case T_CypherMapExpr:
 			retval = _equalCypherMapExpr(a, b);
+			break;
+		case T_CypherAccessExpr:
+			retval = _equalCypherAccessExpr(a, b);
 			break;
 
 			/*

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -267,6 +267,9 @@ exprType(const Node *expr)
 		case T_CypherMapExpr:
 			type = JSONBOID;
 			break;
+		case T_CypherAccessExpr:
+			type = JSONBOID;
+			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d", (int) nodeTag(expr));
 			type = InvalidOid;	/* keep compiler quiet */
@@ -505,6 +508,8 @@ exprTypmod(const Node *expr)
 		case T_EdgeRefRows:
 			return -1;
 		case T_CypherMapExpr:
+			return -1;
+		case T_CypherAccessExpr:
 			return -1;
 		default:
 			break;
@@ -946,6 +951,9 @@ exprCollation(const Node *expr)
 		case T_CypherMapExpr:
 			coll = InvalidOid;
 			break;
+		case T_CypherAccessExpr:
+			coll = InvalidOid;
+			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d", (int) nodeTag(expr));
 			coll = InvalidOid;	/* keep compiler quiet */
@@ -1147,6 +1155,9 @@ exprSetCollation(Node *expr, Oid collation)
 			Assert(!OidIsValid(collation));
 			break;
 		case T_CypherMapExpr:
+			Assert(!OidIsValid(collation));
+			break;
+		case T_CypherAccessExpr:
 			Assert(!OidIsValid(collation));
 			break;
 		default:
@@ -2253,6 +2264,14 @@ expression_tree_walker(Node *node,
 					return true;
 			}
 			break;
+		case T_CypherAccessExpr:
+			{
+				CypherAccessExpr *a = (CypherAccessExpr *) node;
+
+				if (expression_tree_walker((Node *) a->path, walker, context))
+					return true;
+			}
+			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d",
 				 (int) nodeTag(node));
@@ -3098,6 +3117,16 @@ expression_tree_mutator(Node *node,
 				return (Node *) newnode;
 			}
 			break;
+		case T_CypherAccessExpr:
+			{
+				CypherAccessExpr *a = (CypherAccessExpr *) node;
+				CypherAccessExpr *newnode;
+
+				FLATCOPY(newnode, a, CypherAccessExpr);
+				MUTATE(newnode->path, a->path, List *);
+				return (Node *) newnode;
+			}
+			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d",
 				 (int) nodeTag(node));
@@ -3743,6 +3772,14 @@ raw_expression_tree_walker(Node *node,
 				CypherMapExpr *m = (CypherMapExpr *) node;
 
 				if (walker(m->keyvals, context))
+					return true;
+			}
+			break;
+		case T_CypherAccessExpr:
+			{
+				CypherAccessExpr *a = (CypherAccessExpr *) node;
+
+				if (walker(a->path, context))
 					return true;
 			}
 			break;
@@ -4494,6 +4531,16 @@ raw_expression_tree_mutator(Node *node,
 
 				FLATCOPY(newnode, m, CypherMapExpr);
 				MUTATE(newnode->keyvals, m->keyvals, List *);
+				return (Node *) newnode;
+			}
+			break;
+		case T_CypherAccessExpr:
+			{
+				CypherAccessExpr *a = (CypherAccessExpr *) node;
+				CypherAccessExpr *newnode;
+
+				FLATCOPY(newnode, a, CypherAccessExpr);
+				MUTATE(newnode->path, a->path, List *);
 				return (Node *) newnode;
 			}
 			break;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1673,6 +1673,15 @@ _outCypherMapExpr(StringInfo str, const CypherMapExpr *node)
 	WRITE_LOCATION_FIELD(location);
 }
 
+static void
+_outCypherAccessExpr(StringInfo str, const CypherAccessExpr *node)
+{
+	WRITE_NODE_TYPE("CYPHERACCESSEXPR");
+
+	WRITE_NODE_FIELD(arg);
+	WRITE_NODE_FIELD(path);
+}
+
 
 /*****************************************************************************
  *
@@ -3999,6 +4008,9 @@ outNode(StringInfo str, const void *obj)
 				break;
 			case T_CypherMapExpr:
 				_outCypherMapExpr(str, obj);
+				break;
+			case T_CypherAccessExpr:
+				_outCypherAccessExpr(str, obj);
 				break;
 			case T_Path:
 				_outPath(str, obj);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2416,6 +2416,17 @@ _readCypherMapExpr(void)
 	READ_DONE();
 }
 
+static CypherAccessExpr *
+_readCypherAccessExpr(void)
+{
+	READ_LOCALS(CypherAccessExpr);
+
+	READ_NODE_FIELD(arg);
+	READ_NODE_FIELD(path);
+
+	READ_DONE();
+}
+
 /*
  * parseNodeString
  *
@@ -2668,6 +2679,8 @@ parseNodeString(void)
 		return_value = _readEdgeRefRows();
 	else if (MATCH("CYPHERMAPEXPR", 13))
 		return_value = _readCypherMapExpr();
+	else if (MATCH("CYPHERACCESSEXPR", 16))
+		return_value = _readCypherAccessExpr();
 	else
 	{
 		elog(ERROR, "badly formatted node string \"%.32s\"...", token);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -15634,10 +15634,19 @@ cypher_expr:
 					ind->lidx = NULL;
 					ind->uidx = $3;
 
-					n = makeNode(A_Indirection);
-					n->arg = $1;
-					n->indirection = list_make1(ind);
-					$$ = (Node *) n;
+					if (IsA($1, A_Indirection))
+					{
+						n = (A_Indirection *) $1;
+						n->indirection = lappend(n->indirection, ind);
+						$$ = $1;
+					}
+					else
+					{
+						n = makeNode(A_Indirection);
+						n->arg = $1;
+						n->indirection = list_make1(ind);
+						$$ = (Node *) n;
+					}
 				}
 			| cypher_expr '[' cypher_expr_opt DOT_DOT cypher_expr_opt ']'
 				{
@@ -15649,10 +15658,19 @@ cypher_expr:
 					ind->lidx = $3;
 					ind->uidx = $5;
 
-					n = makeNode(A_Indirection);
-					n->arg = $1;
-					n->indirection = list_make1(ind);
-					$$ = (Node *) n;
+					if (IsA($1, A_Indirection))
+					{
+						n = (A_Indirection *) $1;
+						n->indirection = lappend(n->indirection, ind);
+						$$ = $1;
+					}
+					else
+					{
+						n = makeNode(A_Indirection);
+						n->arg = $1;
+						n->indirection = list_make1(ind);
+						$$ = (Node *) n;
+					}
 				}
 			| cypher_expr IS NULL_P							%prec IS
 				{
@@ -15680,10 +15698,19 @@ cypher_expr:
 				{
 					A_Indirection *n;
 
-					n = makeNode(A_Indirection);
-					n->arg = $1;
-					n->indirection = list_make1($3);
-					$$ = (Node *) n;
+					if (IsA($1, A_Indirection))
+					{
+						n = (A_Indirection *) $1;
+						n->indirection = lappend(n->indirection, $3);
+						$$ = $1;
+					}
+					else
+					{
+						n = makeNode(A_Indirection);
+						n->arg = $1;
+						n->indirection = list_make1($3);
+						$$ = (Node *) n;
+					}
 				}
 			| cypher_expr_atom
 		;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1057,6 +1057,13 @@ typedef struct CypherMapExprState
 	List	   *keyvals;		/* key, value, key, value, ... (ExprState's) */
 } CypherMapExprState;
 
+typedef struct CypherAccessExprState
+{
+	ExprState	xprstate;
+	ExprState  *arg;
+	List	   *path;
+} CypherAccessExprState;
+
 /* ----------------------------------------------------------------
  *				 Executor State Trees
  *

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -193,6 +193,7 @@ typedef enum NodeTag
 	T_EdgeRefRow,
 	T_EdgeRefRows,
 	T_CypherMapExpr,
+	T_CypherAccessExpr,
 
 	/*
 	 * TAGS FOR EXPRESSION STATE NODES (execnodes.h)
@@ -232,6 +233,7 @@ typedef enum NodeTag
 	T_EdgeRefRowState,
 	T_EdgeRefRowsState,
 	T_CypherMapExprState,
+	T_CypherAccessExprState,
 
 	/*
 	 * TAGS FOR PLANNER NODES (relation.h)

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -1459,4 +1459,11 @@ typedef struct CypherMapExpr
 	int			location;
 } CypherMapExpr;
 
+typedef struct CypherAccessExpr
+{
+	Expr		xpr;
+	Expr	   *arg;
+	List	   *path;
+} CypherAccessExpr;
+
 #endif   /* PRIMNODES_H */


### PR DESCRIPTION
* Accessing non-exisiting properties returns null.
* `o.null`, `o.'null'`, `o[null]`, `o[NULL]`, and `o['null']` are equal.
* `o.true`, `o.'true'`, `o[true]`, `o[TRUE]`, and `o['true']` are equal.
* Property access on null is null. (e.g. `null.p`)
* Number, map, and list are invalid for the key value.

Let's assume that there is a map `m` with `{p1: 0, 'p\n2': {p3: 1}}`.

Both `m.p1` and `m['p' + 1]` will return `0`.

`m.'p\n2'` will return `{p3: 1}`. However, `m['p\n2']` will return null.
This is because `'p\n2'` in the definition of `m` is equal to that in
`m.'p\n2'` (a string which has 4 characters) but is different from that
in `m['p\n2']` (a string which has 2 characters and a newline character
in the middle). The `.` operator takes an identifier and use it AS-IS.
On the other hand, the `[]` operator takes an expression. This means
escaped characters in the string are processed before using it.

Users may use these two operators consecutively. For example,

`m.p1['p\\n2'].'p3'` will return `1`.