### PR TITLE
fix: VLE produeces invalid results.

### DIFF
--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -1382,6 +1382,13 @@ transformComponents(ParseState *pstate, List *components, List **targetList)
 				{
 					Node *earr;
 
+					if (out == true)
+						ereport(ERROR,
+								(errcode(ERRCODE_SYNTAX_ERROR),
+								 errmsg("Graph path and Variable length edge can not be used at the same time."),
+								 parser_errposition(pstate,
+													getCypherNameLoc(p->variable))));
+
 					earr = getColumnVar(pstate, edge, VLE_COLNAME_ROWIDS);
 					uearrs = list_append_unique(uearrs, earr);
 				}


### PR DESCRIPTION
- Fixed an issue where Seqscan in VLE caused incorrect results.
- Prevent graphpath and VLE from being used together.