### PR TITLE
fix: Bug fix for pg_dump

### DIFF
--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -615,6 +615,9 @@ RestoreArchive(Archive *AHX)
 		if (AH->currSchema)
 			free(AH->currSchema);
 		AH->currSchema = NULL;
+		if (AH->currGraph)
+			free(AH->currGraph);
+		AH->currGraph = NULL;
 	}
 
 	/*
@@ -2283,6 +2286,7 @@ _allocAH(const char *FileSpec, const ArchiveFormat fmt,
 
 	AH->currUser = NULL;		/* unknown */
 	AH->currSchema = NULL;		/* ditto */
+	AH->currGraph = NULL;		/* ditto */
 	AH->currTablespace = NULL;	/* ditto */
 	AH->currWithOids = -1;		/* force SET */
 
@@ -3033,6 +3037,9 @@ _reconnectToDB(ArchiveHandle *AH, const char *dbname)
 	if (AH->currSchema)
 		free(AH->currSchema);
 	AH->currSchema = NULL;
+	if (AH->currGraph)
+		free(AH->currGraph);
+	AH->currGraph = NULL;
 	if (AH->currTablespace)
 		free(AH->currTablespace);
 	AH->currTablespace = NULL;
@@ -3105,19 +3112,16 @@ static void
 _selectOutputSchema(ArchiveHandle *AH, const char *schemaName, teSection sec)
 {
 	PQExpBuffer qry;
-	static teSection oldsec = SECTION_NONE;
 
-	if (oldsec == SECTION_NONE && sec == SECTION_POST_DATA)
+	if (!schemaName || *schemaName == '\0')
+		return;
+	else if	(AH->currSchema && strcmp(AH->currSchema, schemaName) == 0)
 	{
-		oldsec = sec;
-		if (AH->currSchema)
-			free(AH->currSchema);
-		AH->currSchema = NULL;
+		if (sec < SECTION_POST_DATA)
+			return;					/* no need to do anything */
+		else if (AH->currGraph && strcmp(AH->currGraph, schemaName) == 0)
+			return;
 	}
-
-	if (!schemaName || *schemaName == '\0' ||
-		(AH->currSchema && strcmp(AH->currSchema, schemaName) == 0))
-		return;					/* no need to do anything */
 
 	qry = createPQExpBuffer();
 
@@ -3140,7 +3144,13 @@ _selectOutputSchema(ArchiveHandle *AH, const char *schemaName, teSection sec)
 		res = ExecuteSqlQuery(&AH->public, tmp->data, PGRES_TUPLES_OK);
 
 		if (PQntuples(res) > 0)
+		{
 			appendPQExpBuffer(qry, ";\nSET graph_path = %s", fmtId(schemaName));
+
+			if (AH->currGraph)
+				free(AH->currGraph);
+			AH->currGraph = pg_strdup(schemaName);
+		}
 
 		PQclear(res);
 		destroyPQExpBuffer(tmp);
@@ -3788,6 +3798,9 @@ restore_toc_entries_prefork(ArchiveHandle *AH)
 	if (AH->currSchema)
 		free(AH->currSchema);
 	AH->currSchema = NULL;
+	if (AH->currGraph)
+		free(AH->currGraph);
+	AH->currGraph = NULL;
 	if (AH->currTablespace)
 		free(AH->currTablespace);
 	AH->currTablespace = NULL;
@@ -4489,6 +4502,7 @@ CloneArchive(ArchiveHandle *AH)
 	clone->connCancel = NULL;
 	clone->currUser = NULL;
 	clone->currSchema = NULL;
+	clone->currGraph = NULL;
 	clone->currTablespace = NULL;
 	clone->currWithOids = -1;
 
@@ -4579,6 +4593,8 @@ DeCloneArchive(ArchiveHandle *AH)
 		free(AH->currUser);
 	if (AH->currSchema)
 		free(AH->currSchema);
+	if (AH->currGraph)
+		free(AH->currGraph);
 	if (AH->currTablespace)
 		free(AH->currTablespace);
 	if (AH->savedPassword)

--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -3105,6 +3105,15 @@ static void
 _selectOutputSchema(ArchiveHandle *AH, const char *schemaName, teSection sec)
 {
 	PQExpBuffer qry;
+	static teSection oldsec = SECTION_NONE;
+
+	if (oldsec == SECTION_NONE && sec == SECTION_POST_DATA)
+	{
+		oldsec = sec;
+		if (AH->currSchema)
+			free(AH->currSchema);
+		AH->currSchema = NULL;
+	}
 
 	if (!schemaName || *schemaName == '\0' ||
 		(AH->currSchema && strcmp(AH->currSchema, schemaName) == 0))
@@ -3117,7 +3126,7 @@ _selectOutputSchema(ArchiveHandle *AH, const char *schemaName, teSection sec)
 	if (strcmp(schemaName, "pg_catalog") != 0)
 		appendPQExpBufferStr(qry, ", pg_catalog");
 
-	if (sec > SECTION_PRE_DATA)
+	if (sec == SECTION_POST_DATA)
 	{
 		PQExpBuffer tmp;
 		PGresult   *res;

--- a/src/bin/pg_dump/pg_backup_archiver.h
+++ b/src/bin/pg_dump/pg_backup_archiver.h
@@ -321,6 +321,7 @@ struct _archiveHandle
 	/* these vars track state to avoid sending redundant SET commands */
 	char	   *currUser;		/* current username, or NULL if unknown */
 	char	   *currSchema;		/* current schema, or NULL */
+	char	   *currGraph;		/* current graph, or NULL */
 	char	   *currTablespace; /* current tablespace, or NULL */
 	bool		currWithOids;	/* current default_with_oids setting */
 


### PR DESCRIPTION
If there is only 1 graph in database, graph_path is not dumped.
So property indexes can not be restored.