### PR TITLE
feat: Support =~ Operator for regex matching

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -816,7 +816,7 @@ static List *preserve_downcasing_type_func_namelist(List *namelist);
 %left		AT				/* sets precedence for AT TIME ZONE */
 %left		COLLATE
 %right		UMINUS
-%nonassoc	CONTAINS ENDS STARTS
+%nonassoc	CONTAINS ENDS EQUALS_TILDE STARTS
 %left		'[' ']'
 %left		'(' ')'
 %left		TYPECAST
@@ -15132,6 +15132,12 @@ cypher_expr:
 			| cypher_expr IN_P cypher_expr
 				{
 					$$ = (Node *) makeSimpleA_Expr(AEXPR_IN, "=", $1, $3, @2);
+				}
+			| cypher_expr EQUALS_TILDE cypher_expr
+				{
+					$$ = (Node *) makeFuncCall(
+										SystemFuncName("string_regex"),
+										list_make2($1, $3), @2);
 				}
 			| cypher_expr STARTS WITH cypher_expr			%prec STARTS
 				{

--- a/src/backend/parser/scan.l
+++ b/src/backend/parser/scan.l
@@ -335,6 +335,7 @@ identifier		{ident_start}{ident_cont}*
 /* Assorted special-case operators and operator-like tokens */
 typecast		"::"
 dot_dot			\.\.
+equals_tilde	"=~"
 colon_equals	":="
 equals_greater	"=>"
 less_equals		"<="
@@ -825,6 +826,11 @@ other			.
 {dot_dot}		{
 					SET_YYLLOC();
 					return DOT_DOT;
+				}
+
+{equals_tilde}	{
+					SET_YYLLOC();
+					return EQUALS_TILDE;
 				}
 
 {colon_equals}	{

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5569,6 +5569,8 @@ DATA(insert OID = 7242 ( string_ends_with	PGNSP PGUID 12 1 0 0 0 f f f f t f i s
 DESCR("true if the end of LHS matches RHS");
 DATA(insert OID = 7243 ( string_contains	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 2 0 16 "3802 3802" _null_ _null_ _null_ _null_ _null_ jsonb_string_contains _null_ _null_ _null_ ));
 DESCR("true if LHS contains RHS");
+DATA(insert OID = 7244 ( string_regex	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 2 0 16 "3802 3802" _null_ _null_ _null_ _null_ _null_ jsonb_string_regex _null_ _null_ _null_ ));
+DESCR("true if regex match");
 
 /*
  * Symbolic values for provolatile column: these indicate whether the result

--- a/src/include/utils/cypher_funcs.h
+++ b/src/include/utils/cypher_funcs.h
@@ -64,5 +64,6 @@ extern Datum jsonb_trim(PG_FUNCTION_ARGS);
 extern Datum jsonb_string_starts_with(PG_FUNCTION_ARGS);
 extern Datum jsonb_string_ends_with(PG_FUNCTION_ARGS);
 extern Datum jsonb_string_contains(PG_FUNCTION_ARGS);
+extern Datum jsonb_string_regex(PG_FUNCTION_ARGS);
 
 #endif	/* CYPHER_FUNCS_H */

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -2763,6 +2763,7 @@ SET allow_null_properties = off;
 --
 -- String Matching
 --
+-- starts with
 RETURN 'abc' STARTS WITH 'a';
  string_starts_with 
 --------------------
@@ -2789,6 +2790,7 @@ RETURN 'abc' STARTS WITH 'abcd';
 
 RETURN 'abc' STARTS WITH 1;
 ERROR:  STARTS WITH: two string values expected but "abc", 1
+-- ends with
 RETURN 'abc' ENDS WITH 'c';
  string_ends_with 
 ------------------
@@ -2815,6 +2817,7 @@ RETURN 'abc' ENDS WITH 'abcd';
 
 RETURN 'abc' ENDS WITH 1;
 ERROR:  ENDS WITH: two string values expected but "abc", 1
+-- contains
 RETURN 'abc' CONTAINS 'b';
  string_contains 
 -----------------
@@ -2835,6 +2838,45 @@ RETURN 'abc' CONTAINS 'abcd';
 
 RETURN 'abc' CONTAINS 1;
 ERROR:  CONTAINS: two string values expected but "abc", 1
+-- =~
+RETURN 'abc' =~ 'abc';
+ string_regex 
+--------------
+ t
+(1 row)
+
+RETURN 'abc' =~ '';
+ string_regex 
+--------------
+ t
+(1 row)
+
+RETURN 'abc' =~ 'a';
+ string_regex 
+--------------
+ t
+(1 row)
+
+RETURN 'abc' =~ 'abcd';
+ string_regex 
+--------------
+ f
+(1 row)
+
+RETURN 'abc' =~ '(?i)A';
+ string_regex 
+--------------
+ t
+(1 row)
+
+RETURN 'abc' =~ 'a(b{1})c';
+ string_regex 
+--------------
+ t
+(1 row)
+
+RETURN 'abc' =~ 1;
+ERROR:  Regular Expression Pattern: two string values expected but "abc", 1
 -- cleanup
 DROP GRAPH np CASCADE;
 NOTICE:  drop cascades to 5 other objects

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -1063,11 +1063,15 @@ SET allow_null_properties = off;
 -- String Matching
 --
 
+-- starts with
+
 RETURN 'abc' STARTS WITH 'a';
 RETURN 'abc' STARTS WITH '';
 RETURN 'abc' STARTS WITH 'bc';
 RETURN 'abc' STARTS WITH 'abcd';
 RETURN 'abc' STARTS WITH 1;
+
+-- ends with
 
 RETURN 'abc' ENDS WITH 'c';
 RETURN 'abc' ENDS WITH '';
@@ -1075,10 +1079,22 @@ RETURN 'abc' ENDS WITH 'ab';
 RETURN 'abc' ENDS WITH 'abcd';
 RETURN 'abc' ENDS WITH 1;
 
+-- contains
+
 RETURN 'abc' CONTAINS 'b';
 RETURN 'abc' CONTAINS '';
 RETURN 'abc' CONTAINS 'abcd';
 RETURN 'abc' CONTAINS 1;
+
+-- =~
+
+RETURN 'abc' =~ 'abc';
+RETURN 'abc' =~ '';
+RETURN 'abc' =~ 'a';
+RETURN 'abc' =~ 'abcd';
+RETURN 'abc' =~ '(?i)A';
+RETURN 'abc' =~ 'a(b{1})c';
+RETURN 'abc' =~ 1;
 
 -- cleanup
 


### PR DESCRIPTION
* Added support for the =~ operator for regex matching.

* =~ follows the ARE standard that is included with postgresql

* =~ Ex: RETURN 'abc' =~ 'a(b*)c';