### PR TITLE
fix: Nested use of variables in list comprehension

### DIFF
--- a/src/backend/executor/execQual.c
+++ b/src/backend/executor/execQual.c
@@ -4827,6 +4827,8 @@ ExecEvalCypherListComp(CypherListCompExprState *clcstate,
 	bool		eisnull;
 	Datum		listd;
 	Jsonb	   *listj;
+	Datum		save_datum;
+	bool		save_isNull;
 	JsonbParseState *jpstate = NULL;
 	JsonbIterator *it;
 	JsonbValue	jv;
@@ -4851,6 +4853,9 @@ ExecEvalCypherListComp(CypherListCompExprState *clcstate,
 						JsonbToCString(NULL, &listj->root, VARSIZE(listj)))));
 		return 0;
 	}
+
+	save_datum = econtext->clcValue_datum;
+	save_isNull = econtext->clcValue_isNull;
 
 	pushJsonbValue(&jpstate, WJB_BEGIN_ARRAY, NULL);
 
@@ -4930,8 +4935,8 @@ ExecEvalCypherListComp(CypherListCompExprState *clcstate,
 		}
 	}
 
-	econtext->clcValue_datum = 0;
-	econtext->clcValue_isNull = true;
+	econtext->clcValue_datum = save_datum;
+	econtext->clcValue_isNull = save_isNull;
 
 	j = pushJsonbValue(&jpstate, WJB_END_ARRAY, NULL);
 

--- a/src/test/regress/expected/cypher_expr.out
+++ b/src/test/regress/expected/cypher_expr.out
@@ -496,6 +496,13 @@ RETURN [x IN [0, 1, 2, 3, 4] WHERE x % 2 = 0 | x + 1];
  [1, 3, 5]
 (1 row)
 
+-- nested use of variables
+RETURN [x IN [[0], [1]] WHERE length([y IN x]) = 1 | [y IN x]];
+  ?column?  
+------------
+ [[0], [1]]
+(1 row)
+
 -- List predicate functions
 RETURN ALL(x in [] WHERE x = 0);
  ?column? 

--- a/src/test/regress/sql/cypher_expr.sql
+++ b/src/test/regress/sql/cypher_expr.sql
@@ -221,6 +221,8 @@ RETURN [x IN [0, 1, 2, 3, 4]];
 RETURN [x IN [0, 1, 2, 3, 4] WHERE x % 2 = 0];
 RETURN [x IN [0, 1, 2, 3, 4] | x + 1];
 RETURN [x IN [0, 1, 2, 3, 4] WHERE x % 2 = 0 | x + 1];
+-- nested use of variables
+RETURN [x IN [[0], [1]] WHERE length([y IN x]) = 1 | [y IN x]];
 
 -- List predicate functions
 RETURN ALL(x in [] WHERE x = 0);


### PR DESCRIPTION
Inner variable overwrites outer variable and it produces unexpected
result.

`RETURN [x IN [[0], [1]] WHERE length([y IN x]) = 1 | [y IN x]];`

Above query should produce `[[0], [1]]` but `[null, null]`.