### PR TITLE
Feat support drop vlabel cascade

### DIFF
--- a/src/backend/catalog/ag_graph.c
+++ b/src/backend/catalog/ag_graph.c
@@ -29,6 +29,7 @@
 
 /* a global variable for the GUC variable */
 char *graph_path = NULL;
+bool enableGraphDML = false;
 
 /* check_hook: validate new graph_path value */
 bool

--- a/src/backend/commands/dropcmds.c
+++ b/src/backend/commands/dropcmds.c
@@ -16,6 +16,7 @@
 
 #include "access/heapam.h"
 #include "access/htup_details.h"
+#include "catalog/ag_graph_fn.h"
 #include "catalog/dependency.h"
 #include "catalog/namespace.h"
 #include "catalog/objectaddress.h"
@@ -27,6 +28,7 @@
 #include "nodes/makefuncs.h"
 #include "parser/parse_type.h"
 #include "utils/builtins.h"
+#include "utils/rel.h"
 #include "utils/syscache.h"
 
 
@@ -109,9 +111,41 @@ RemoveObjects(DropStmt *stmt)
 			ReleaseSysCache(tup);
 		}
 
-		if (stmt->removeType == OBJECT_ELABEL ||
-			stmt->removeType == OBJECT_VLABEL)
-			CheckLabelType(stmt->removeType, address.objectId, "DROP");
+		if (stmt->removeType == OBJECT_VLABEL)
+		{
+			CheckLabelType(OBJECT_VLABEL, address.objectId, "DROP");
+
+			if (stmt->behavior == DROP_CASCADE)
+			{
+				deleteRelatedEdges(
+						makeRangeVarFromNameList(castNode(List, object)));
+			}
+			else
+			{
+				Assert(stmt->behavior == DROP_RESTRICT);
+
+				if (!isEmptyLabel(NameListToString(castNode(List, object))))
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("cannot drop %s because it is not empty.",
+									 NameListToString(castNode(List, object)))));
+				}
+			}
+		}
+		else if (stmt->removeType == OBJECT_ELABEL)
+		{
+			CheckLabelType(OBJECT_ELABEL, address.objectId, "DROP");
+
+			if (stmt->behavior == DROP_RESTRICT &&
+				!isEmptyLabel(NameListToString(castNode(List, object))))
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("cannot drop %s because it is not empty.",
+								 NameListToString(castNode(List, object)))));
+			}
+		}
 
 		/* Check permissions. */
 		namespaceId = get_object_namespace(&address);

--- a/src/backend/commands/graphcmds.c
+++ b/src/backend/commands/graphcmds.c
@@ -651,10 +651,12 @@ deleteRelatedEdges(RangeVar *vlab)
 		if (ret != SPI_OK_CONNECT)
 			elog(ERROR, "deleteRelatedEdges: SPI_connect returned %d", ret);
 
+		enableGraphDML = true;
 		ret = SPI_execute(sql.data, false, 0);
 		if (ret != SPI_OK_DELETE)
 			elog(ERROR, "deleteRelatedEdges: SPI_execute returned %d: %s",
 				 ret, sql.data);
+		enableGraphDML = false;
 
 		ret = SPI_finish();
 		if (ret != SPI_OK_FINISH)

--- a/src/backend/commands/graphcmds.c
+++ b/src/backend/commands/graphcmds.c
@@ -25,6 +25,7 @@
 #include "catalog/objectaccess.h"
 #include "catalog/objectaddress.h"
 #include "catalog/pg_class.h"
+#include "catalog/pg_inherits_fn.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/toasting.h"
 #include "commands/event_trigger.h"
@@ -32,6 +33,7 @@
 #include "commands/schemacmds.h"
 #include "commands/tablecmds.h"
 #include "commands/tablespace.h"
+#include "executor/spi.h"
 #include "nodes/params.h"
 #include "nodes/parsenodes.h"
 #include "parser/parse_utilcmd.h"
@@ -357,13 +359,11 @@ GetSuperOids(List *supers, char labkind, List **supOids)
 static void
 AgInheritanceDependancy(Oid laboid, List *supers)
 {
-	int16		seq;
 	ListCell   *entry;
 
 	if (supers == NIL)
 		return;
 
-	seq = 1;
 	foreach(entry, supers)
 	{
 		Oid parentOid = lfirst_oid(entry);
@@ -377,8 +377,6 @@ AgInheritanceDependancy(Oid laboid, List *supers)
 		parentobject.objectId = parentOid;
 		parentobject.objectSubId = 0;
 		recordDependencyOn(&childobject, &parentobject, DEPENDENCY_NORMAL);
-
-		seq++;
 	}
 }
 
@@ -578,4 +576,90 @@ DisableIndexCommand(DisableIndexStmt *disableStmt)
 						relation->relname)));
 
 	return relid;
+}
+
+bool
+isEmptyLabel(char *label_name)
+{
+	int	   ret;
+	StringInfoData sql;
+	bool   result = true;
+
+	initStringInfo(&sql);
+
+	appendStringInfo(&sql, "SELECT 1 FROM %s.%s LIMIT 1",
+					 get_graph_path(false), label_name);
+
+	ret = SPI_connect();
+	if (ret != SPI_OK_CONNECT)
+		elog(ERROR, "isEmptyLabel: SPI_connect returned %d", ret);
+
+	ret = SPI_execute(sql.data, true, 1);
+	if (ret != SPI_OK_SELECT)
+		elog(ERROR, "isEmptyLabel: SPI_execute returned %d: %s",
+			 ret, sql.data);
+
+	if (SPI_processed > 0)
+		result = false;
+
+	ret = SPI_finish();
+	if (ret != SPI_OK_FINISH)
+		elog(ERROR, "isEmptyLabel: SPI_finish returned %d", ret);
+
+	return result;
+}
+
+void
+deleteRelatedEdges(RangeVar *vlab)
+{
+	uint32		vlabid;
+	Oid			graphoid;
+	Oid			agedge;
+	ListCell   *lc;
+	List	   *edges = NIL;
+
+	graphoid = get_graph_path_oid();
+	vlabid = (uint32) get_labname_labid(vlab->relname, graphoid);
+
+	/* get all edge's relid */
+	agedge = get_laboid_relid(get_labname_laboid(AG_EDGE, graphoid));
+	edges = list_make1_oid(agedge);
+	edges = list_concat(edges, find_all_inheritors(agedge, NoLock, NULL));
+
+	foreach(lc, edges)
+	{
+		Oid		   edgeoid = lfirst_oid(lc);
+		Relation   rel;
+		int		   ret;
+		StringInfoData sql;
+
+		/* Hold the ShareLock to prevent DML on the edge label */
+		rel = try_relation_open(edgeoid, ShareLock);
+		if (rel == NULL)
+			continue;	/* not exist */
+
+		initStringInfo(&sql);
+
+		appendStringInfo(&sql, "DELETE FROM ONLY %s.%s WHERE"
+						 " (start >= graphid(%u,0) AND start < graphid(%u,"UINT64_FORMAT")) OR"
+						 " (\"end\" >= graphid(%u,0) AND \"end\" < graphid(%u,"UINT64_FORMAT"))",
+						 get_graph_path(false), RelationGetRelationName(rel),
+						 vlabid, vlabid, GRAPHID_LOCID_MAX,
+						 vlabid, vlabid, GRAPHID_LOCID_MAX);
+
+		ret = SPI_connect();
+		if (ret != SPI_OK_CONNECT)
+			elog(ERROR, "deleteRelatedEdges: SPI_connect returned %d", ret);
+
+		ret = SPI_execute(sql.data, false, 0);
+		if (ret != SPI_OK_DELETE)
+			elog(ERROR, "deleteRelatedEdges: SPI_execute returned %d: %s",
+				 ret, sql.data);
+
+		ret = SPI_finish();
+		if (ret != SPI_OK_FINISH)
+			elog(ERROR, "deleteRelatedEdges: SPI_finish returned %d", ret);
+
+		relation_close(rel, ShareLock);
+	}
 }

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -416,7 +416,7 @@ transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt)
 
 	qry->commandType = CMD_DELETE;
 
-	if (RangeVarIsLabel(stmt->relation))
+	if (RangeVarIsLabel(stmt->relation) && !enableGraphDML)
 		elog(ERROR, "DML query to graph objects is not allowed");
 
 	/* process the WITH clause independently of all else */
@@ -499,7 +499,7 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 	bool		isOnConflictUpdate;
 	AclMode		targetPerms;
 
-	if (RangeVarIsLabel(stmt->relation))
+	if (RangeVarIsLabel(stmt->relation) && !enableGraphDML)
 		elog(ERROR, "DML query to graph objects is not allowed");
 
 	/* There can't be any outer WITH to worry about */
@@ -2235,7 +2235,7 @@ transformUpdateStmt(ParseState *pstate, UpdateStmt *stmt)
 	ParseNamespaceItem *nsitem;
 	Node	   *qual;
 
-	if (RangeVarIsLabel(stmt->relation))
+	if (RangeVarIsLabel(stmt->relation) && !enableGraphDML)
 		elog(ERROR, "DML query to graph objects is not allowed");
 
 	qry->commandType = CMD_UPDATE;

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -854,6 +854,8 @@ PortalRun(Portal portal, long count, bool isTopLevel, bool run_once,
 			CurrentResourceOwner = saveResourceOwner;
 		PortalContext = savePortalContext;
 
+		enableGraphDML = false;
+
 		PG_RE_THROW();
 	}
 	PG_END_TRY();

--- a/src/include/catalog/ag_graph_fn.h
+++ b/src/include/catalog/ag_graph_fn.h
@@ -13,7 +13,7 @@
 #include "nodes/parsenodes.h"
 
 extern char *graph_path;
-extern bool DisableGraphDML;
+extern bool enableGraphDML;
 
 extern char *get_graph_path(bool lookup_cache);
 extern Oid get_graph_path_oid(void);

--- a/src/include/catalog/ag_graph_fn.h
+++ b/src/include/catalog/ag_graph_fn.h
@@ -13,6 +13,7 @@
 #include "nodes/parsenodes.h"
 
 extern char *graph_path;
+extern bool DisableGraphDML;
 
 extern char *get_graph_path(bool lookup_cache);
 extern Oid get_graph_path_oid(void);

--- a/src/include/commands/graphcmds.h
+++ b/src/include/commands/graphcmds.h
@@ -35,4 +35,7 @@ extern void DropConstraintCommand(DropConstraintStmt *constraintStmt,
 
 extern Oid DisableIndexCommand(DisableIndexStmt *disableStmt);
 
+extern bool isEmptyLabel(char *label_name);
+extern void deleteRelatedEdges(RangeVar *vlab);
+
 #endif	/* GRAPHCMDS_H */

--- a/src/test/regress/expected/cypher_ddl.out
+++ b/src/test/regress/expected/cypher_ddl.out
@@ -596,6 +596,17 @@ SELECT labname, labkind FROM pg_catalog.ag_label;
  vdi       | v
 (6 rows)
 
+-- drop label non-empty
+CREATE (a:test_v1)-[:test_e1]->(b:test_v2), (a)<-[:test_e2]-(b);
+DROP ELABEL test_e1;
+ERROR:  cannot drop test_e1 because it is not empty.
+DROP ELABEL test_e2 CASCADE;
+DROP VLABEL test_v1;
+ERROR:  cannot drop test_v1 because it is not empty.
+DROP VLABEL test_v2 CASCADE;
+MATCH (a:test_v1) DELETE (a);
+DROP VLABEL test_v1;
+DROP ELABEL test_e1;
 --
 -- CONSTRAINT
 --
@@ -626,7 +637,7 @@ CREATE (:regv1 {a: 'b'});
 ERROR:  map or list is expected but scalar value
 CREATE (:regv1 {a: 'agens-graph'});
 ERROR:  map or list is expected but scalar value
-DROP VLABEL regv1;
+DROP VLABEL regv1 CASCADE;
 -- expr unique constraint
 CREATE ELABEL rege1;
 CREATE CONSTRAINT ON rege1 ASSERT c + d IS UNIQUE;
@@ -649,7 +660,7 @@ ERROR:  conflicting key value violates exclusion constraint "rege1_unique_constr
 CREATE ()-[:rege1 {c: 'agens', d: 'rdb'}]->();
 CREATE ()-[:rege1 {c: 'agen', d: 'sgraph'}]->();
 ERROR:  conflicting key value violates exclusion constraint "rege1_unique_constraint"
-DROP ELABEL rege1;
+DROP ELABEL rege1 CASCADE;
 -- simple not null constraint
 CREATE VLABEL regv2;
 CREATE CONSTRAINT ON regv2 ASSERT name IS NOT NULL;
@@ -672,7 +683,7 @@ ERROR:  new row for relation "regv2" violates check constraint "regv2_properties
 CREATE (:regv2 {age: 0, name: 'graph'});
 CREATE (:regv2 {name: NULL});
 ERROR:  new row for relation "regv2" violates check constraint "regv2_properties_check"
-DROP VLABEL regv2;
+DROP VLABEL regv2 CASCADE;
 -- multi not null constraint
 CREATE VLABEL regv3;
 CREATE CONSTRAINT ON regv3 ASSERT name.first IS NOT NULL AND name.last IS NOT NULL;
@@ -698,7 +709,7 @@ CREATE (:regv3 {name: {last: 'graph'}});
 ERROR:  new row for relation "regv3" violates check constraint "regv3_properties_check"
 CREATE (:regv3 {name: {first: NULL, last: NULL}});
 ERROR:  new row for relation "regv3" violates check constraint "regv3_properties_check"
-DROP VLABEL regv3;
+DROP VLABEL regv3 CASCADE;
 -- simple check constraint
 CREATE ELABEL rege2;
 CREATE CONSTRAINT ON rege2 ASSERT a != b;
@@ -720,7 +731,7 @@ CREATE ()-[:rege2 {a: 'agens', b: 'agens'}]->();
 ERROR:  new row for relation "rege2" violates check constraint "rege2_properties_check"
 CREATE ()-[:rege2 {a: 'agens', b: 'AGENS'}]->();
 CREATE ()-[:rege2 {a: 'agens', d: 'graph'}]->();
-DROP ELABEL rege2;
+DROP ELABEL rege2 CASCADE;
 -- expression check constraint
 CREATE VLABEL regv4;
 CREATE CONSTRAINT ON regv4 ASSERT (length(password) > 8 AND length(password) < 16);
@@ -743,7 +754,7 @@ CREATE (:regv4 {password: '123456789'});
 CREATE (:regv4 {password: '123456789012345'});
 CREATE (:regv4 {password: '1234567890123456'});
 ERROR:  new row for relation "regv4" violates check constraint "regv4_properties_check"
-DROP VLABEL regv4;
+DROP VLABEL regv4 CASCADE;
 -- IN check constraint
 CREATE ELABEL rege3;
 CREATE CONSTRAINT ON rege3 ASSERT type IN ['friend', 'lover', 'parent'];
@@ -766,7 +777,7 @@ ERROR:  new row for relation "rege3" violates check constraint "rege3_properties
 CREATE ()-[:rege3 {type: 'parents', name: 'AGENS'}]->();
 ERROR:  new row for relation "rege3" violates check constraint "rege3_properties_check"
 CREATE ()-[:rege3 {type: 'lover', name: 'GRAPH'}]->();
-DROP ELABEL rege3;
+DROP ELABEL rege3 CASCADE;
 -- case check constraint
 CREATE VLABEL regv5;
 CREATE CONSTRAINT ON regv5 ASSERT toLower(trim(id)) IS UNIQUE;
@@ -795,7 +806,7 @@ ERROR:  conflicting key value violates exclusion constraint "regv5_unique_constr
 CREATE (:regv5 {id: 'GRAPH'});
 CREATE (:regv5 {id: ' graph '});
 ERROR:  conflicting key value violates exclusion constraint "regv5_unique_constraint"
-DROP VLABEL regv5;
+DROP VLABEL regv5 CASCADE;
 -- IS NULL constraint
 CREATE ELABEL rege4;
 CREATE CONSTRAINT rege4_name_isnull_constraint ON rege4 ASSERT id IS NULL;
@@ -821,7 +832,7 @@ ERROR:  constraint "rege4_name_isnull_constraint" of relation "ag_edge" does not
 DROP CONSTRAINT ON rege4;
 ERROR:  syntax error at or near "ON" at character 17
 DROP CONSTRAINT rege4_name_isnull_constraint ON rege4;
-DROP ELABEL rege4;
+DROP ELABEL rege4 CASCADE;
 -- Indirection constraint
 CREATE VLABEL regv7;
 CREATE CONSTRAINT ON regv7 ASSERT a.b[0].c IS NOT NULL;
@@ -842,7 +853,7 @@ CREATE (:regv7 {a: {b: [{c: 'd'}, {c: 'e'}]}});
 CREATE (:regv7 {a: {b: [{c: 'd'}, {e: 'e'}]}});
 CREATE (:regv7 {a: {b: [{d: 'd'}, {e: 'e'}]}});
 ERROR:  new row for relation "regv7" violates check constraint "regv7_properties_check"
-DROP VLABEL regv7;
+DROP VLABEL regv7 CASCADE;
 -- wrong case
 CREATE VLABEL regv8;
 CREATE CONSTRAINT ON regv8 ASSERT (SELECT * FROM graph.regv8).c IS NOT NULL;
@@ -851,7 +862,7 @@ CREATE CONSTRAINT ON regv8 ASSERT (1).c IS NOT NULL;
 ERROR:  map or list is expected but scalar value
 CREATE CONSTRAINT ON regv8 ASSERT ($1).c IS NOT NULL;
 ERROR:  there is no parameter $1
-DROP VLABEL regv8;
+DROP VLABEL regv8 CASCADE;
 --
 -- DROP GRAPH
 --

--- a/src/test/regress/expected/propertyindex.out
+++ b/src/test/regress/expected/propertyindex.out
@@ -200,7 +200,7 @@ Inherits: g.ag_vertex
  g     | regv1     | regv1_id_idx | t      | regressrole | CREATE UNIQUE PROPERTY INDEX regv1_id_idx ON regv1 USING btree (id)
 (1 row)
 
-DROP VLABEL regv1;
+DROP VLABEL regv1 CASCADE;
 -- Multi-column unique property index
 CREATE VLABEL regv1;
 CREATE UNIQUE PROPERTY INDEX ON regv1 (name.first, name.last);
@@ -241,7 +241,7 @@ Inherits: g.ag_vertex
  g     | regv1     | regv1_first_last_idx | t      | regressrole | CREATE UNIQUE PROPERTY INDEX regv1_first_last_idx ON regv1 USING btree (name.first, name.last)
 (1 row)
 
-DROP VLABEL regv1;
+DROP VLABEL regv1 CASCADE;
 -- DROP PROPERTY INDEX
 CREATE VLABEL regv1;
 CREATE PROPERTY INDEX regv1_idx ON regv1 (name);

--- a/src/test/regress/sql/cypher_ddl.sql
+++ b/src/test/regress/sql/cypher_ddl.sql
@@ -217,6 +217,18 @@ DROP ELABEL e0 CASCADE;
 DROP ELABEL e1;
 SELECT labname, labkind FROM pg_catalog.ag_label;
 
+-- drop label non-empty
+CREATE (a:test_v1)-[:test_e1]->(b:test_v2), (a)<-[:test_e2]-(b);
+
+DROP ELABEL test_e1;
+DROP ELABEL test_e2 CASCADE;
+DROP VLABEL test_v1;
+DROP VLABEL test_v2 CASCADE;
+
+MATCH (a:test_v1) DELETE (a);
+DROP VLABEL test_v1;
+DROP ELABEL test_e1;
+
 --
 -- CONSTRAINT
 --
@@ -235,7 +247,7 @@ CREATE (:regv1 {a: {b: 'c'}});
 CREATE (:regv1 {a: 'b'});
 CREATE (:regv1 {a: 'agens-graph'});
 
-DROP VLABEL regv1;
+DROP VLABEL regv1 CASCADE;
 
 -- expr unique constraint
 CREATE ELABEL rege1;
@@ -248,7 +260,7 @@ CREATE ()-[:rege1 {c: 'agens', d: 'graph'}]->();
 CREATE ()-[:rege1 {c: 'agens', d: 'rdb'}]->();
 CREATE ()-[:rege1 {c: 'agen', d: 'sgraph'}]->();
 
-DROP ELABEL rege1;
+DROP ELABEL rege1 CASCADE;
 
 -- simple not null constraint
 CREATE VLABEL regv2;
@@ -261,7 +273,7 @@ CREATE (:regv2 {age: 0});
 CREATE (:regv2 {age: 0, name: 'graph'});
 CREATE (:regv2 {name: NULL});
 
-DROP VLABEL regv2;
+DROP VLABEL regv2 CASCADE;
 
 -- multi not null constraint
 CREATE VLABEL regv3;
@@ -275,7 +287,7 @@ CREATE (:regv3 {name: {first: 'agens'}});
 CREATE (:regv3 {name: {last: 'graph'}});
 CREATE (:regv3 {name: {first: NULL, last: NULL}});
 
-DROP VLABEL regv3;
+DROP VLABEL regv3 CASCADE;
 
 -- simple check constraint
 CREATE ELABEL rege2;
@@ -288,7 +300,7 @@ CREATE ()-[:rege2 {a: 'agens', b: 'agens'}]->();
 CREATE ()-[:rege2 {a: 'agens', b: 'AGENS'}]->();
 CREATE ()-[:rege2 {a: 'agens', d: 'graph'}]->();
 
-DROP ELABEL rege2;
+DROP ELABEL rege2 CASCADE;
 
 -- expression check constraint
 CREATE VLABEL regv4;
@@ -301,7 +313,7 @@ CREATE (:regv4 {password: '123456789'});
 CREATE (:regv4 {password: '123456789012345'});
 CREATE (:regv4 {password: '1234567890123456'});
 
-DROP VLABEL regv4;
+DROP VLABEL regv4 CASCADE;
 
 -- IN check constraint
 CREATE ELABEL rege3;
@@ -314,7 +326,7 @@ CREATE ()-[:rege3 {type: 'love', name: 'graph'}]->();
 CREATE ()-[:rege3 {type: 'parents', name: 'AGENS'}]->();
 CREATE ()-[:rege3 {type: 'lover', name: 'GRAPH'}]->();
 
-DROP ELABEL rege3;
+DROP ELABEL rege3 CASCADE;
 
 -- case check constraint
 CREATE VLABEL regv5;
@@ -330,7 +342,7 @@ CREATE (:regv5 {id: ' AGENS '});
 CREATE (:regv5 {id: 'GRAPH'});
 CREATE (:regv5 {id: ' graph '});
 
-DROP VLABEL regv5;
+DROP VLABEL regv5 CASCADE;
 
 -- IS NULL constraint
 CREATE ELABEL rege4;
@@ -346,7 +358,7 @@ DROP CONSTRAINT rege4_name_isnull_constraint ON ag_edge;
 DROP CONSTRAINT ON rege4;
 DROP CONSTRAINT rege4_name_isnull_constraint ON rege4;
 
-DROP ELABEL rege4;
+DROP ELABEL rege4 CASCADE;
 
 -- Indirection constraint
 
@@ -359,7 +371,7 @@ CREATE (:regv7 {a: {b: [{c: 'd'}, {c: 'e'}]}});
 CREATE (:regv7 {a: {b: [{c: 'd'}, {e: 'e'}]}});
 CREATE (:regv7 {a: {b: [{d: 'd'}, {e: 'e'}]}});
 
-DROP VLABEL regv7;
+DROP VLABEL regv7 CASCADE;
 
 -- wrong case
 
@@ -369,7 +381,7 @@ CREATE CONSTRAINT ON regv8 ASSERT (SELECT * FROM graph.regv8).c IS NOT NULL;
 CREATE CONSTRAINT ON regv8 ASSERT (1).c IS NOT NULL;
 CREATE CONSTRAINT ON regv8 ASSERT ($1).c IS NOT NULL;
 
-DROP VLABEL regv8;
+DROP VLABEL regv8 CASCADE;
 
 --
 -- DROP GRAPH

--- a/src/test/regress/sql/propertyindex.sql
+++ b/src/test/regress/sql/propertyindex.sql
@@ -76,7 +76,7 @@ CREATE (:regv1 {id: 100});
 \d g.regv1
 \dGv+ regv1
 \dGi
-DROP VLABEL regv1;
+DROP VLABEL regv1 CASCADE;
 
 -- Multi-column unique property index
 CREATE VLABEL regv1;
@@ -90,7 +90,7 @@ CREATE (:regv1 {name: {first: 'agens', last: 'graph'}});
 \d g.regv1
 \dGv+ regv1
 \dGi
-DROP VLABEL regv1;
+DROP VLABEL regv1 CASCADE;
 
 -- DROP PROPERTY INDEX
 CREATE VLABEL regv1;


### PR DESCRIPTION
* Prevent to drop label, if label is not empty.
* Performing 'DROP VLABEL' with the CASCADE option removes all edges associated with the target label.