### PR TITLE
test: Clean up regression test for pg_hint_plan

### DIFF
--- a/contrib/pg_hint_plan/Makefile
+++ b/contrib/pg_hint_plan/Makefile
@@ -11,7 +11,7 @@ REGRESS = init base_plan pg_hint_plan ut-init ut-A ut-S ut-J ut-L ut-G ut-R ut-f
 
 REGRESSION_EXPECTED = expected/init.out expected/base_plan.out expected/pg_hint_plan.out expected/ut-A.out expected/ut-S.out expected/ut-J.out expected/ut-L.out expected/ut-G.out
 
-REGRESS_OPTS = --encoding=UTF8
+REGRESS_OPTS = --encoding=UTF8 --temp-config $(top_srcdir)/contrib/pg_stat_statements/pg_stat_statements.conf
 
 EXTENSION = pg_hint_plan
 DATA = pg_hint_plan--1.3.0.sql

--- a/contrib/pg_hint_plan/output/ut-W.source
+++ b/contrib/pg_hint_plan/output/ut-W.source
@@ -3,6 +3,7 @@ ALTER SYSTEM SET session_preload_libraries TO 'pg_hint_plan';
 SET pg_hint_plan.enable_hint TO on;
 SET pg_hint_plan.debug_print TO on;
 SET client_min_messages TO LOG;
+SET work_mem = '16MB';
 CREATE TABLE s1.tl (a int);
 INSERT INTO s1.tl (SELECT a FROM generate_series(0, 100000) a);
 -- Queries on ordinary tables with default setting

--- a/contrib/pg_hint_plan/sql/ut-W.sql
+++ b/contrib/pg_hint_plan/sql/ut-W.sql
@@ -3,6 +3,7 @@ ALTER SYSTEM SET session_preload_libraries TO 'pg_hint_plan';
 SET pg_hint_plan.enable_hint TO on;
 SET pg_hint_plan.debug_print TO on;
 SET client_min_messages TO LOG;
+SET work_mem = '16MB';
 
 
 CREATE TABLE s1.tl (a int);


### PR DESCRIPTION
1. ERROR: To avoid error ( pg_stat_statements must be loaded via shared_preload_libraries ) conf file setting 
2. Prevent diff with setting work_mem ( LOG: temporary file: path )