### PR TITLE
revert: b8d79d0 "fix: Rewrite the logic for auto-generating GROUP BY"

### DIFF
--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -3538,43 +3538,60 @@ transformFrameOffset(ParseState *pstate, int frameOptions, Node *clause)
 	return node;
 }
 
-typedef struct
-{
-	int			sublevels_up;
-} find_var_context;
-
 static bool
-find_var_walker(Node *node, find_var_context *ctx)
+has_column_in_edgeref(Expr *node, int var_level)
 {
-	if (node == NULL)
-		return false;
+	Var *var;
 
 	if (IsA(node, Var))
-		return ((int) ((Var *) node)->varlevelsup == ctx->sublevels_up);
-
-	if (IsA(node, Query))
 	{
-		bool		result;
-
-		ctx->sublevels_up++;
-		result = query_tree_walker((Query *) node, find_var_walker, ctx, 0);
-		ctx->sublevels_up--;
-
-		return result;
+		var = (Var *) node;
+		return (int) var->varlevelsup == var_level;
+	}
+	if (IsA(node, ArrayRef))
+	{
+		ArrayRef *aref = (ArrayRef *) node;
+		return has_column_in_edgeref(aref->refexpr, var_level);
 	}
 
-	return expression_tree_walker(node, find_var_walker, ctx);
+	return false;
+}
+
+static bool
+add_expr_to_group_exprs(Expr *expr, List **group_exprs)
+{
+	ListCell *gl;
+
+	/* check duplication */
+	foreach(gl, *group_exprs)
+	{
+		Expr *gexpr = (Expr *) lfirst(gl);
+
+		if (equal(gexpr, expr))
+			return false;
+	}
+
+	*group_exprs = lappend(*group_exprs, expr);
+	return true;
 }
 
 typedef struct
 {
+	List	   *group_exprs;
 	int			sublevels_up;
-} find_agg_context;
+} gen_group_exprs_context;
 
+/* See check_ungrouped_columns_walker() */
 static bool
-find_agg_walker(Node *node, find_agg_context *ctx)
+gen_group_exprs_walker(Node *node, gen_group_exprs_context *ctx)
 {
+	FieldSelect *fselect;
+	Var *var;
+
 	if (node == NULL)
+		return false;
+
+	if (IsA(node, Const) || IsA(node, Param))
 		return false;
 
 	if (IsA(node, Aggref))
@@ -3583,52 +3600,123 @@ find_agg_walker(Node *node, find_agg_context *ctx)
 		int			agglevelsup = (int) agg->agglevelsup;
 
 		if (agglevelsup == ctx->sublevels_up)
-		{
-			find_var_context fvctx;
-
-			fvctx.sublevels_up = ctx->sublevels_up;
-			if (find_var_walker((Node *) agg->args, &fvctx))
-				return true;
-			if (find_var_walker((Node *) agg->aggdirectargs, &fvctx))
-				return true;
-
-			return false;
-		}
+			return gen_group_exprs_walker((Node *) agg->aggdirectargs, ctx);
 
 		if (agglevelsup > ctx->sublevels_up)
 			return false;
+
+		/* fall-through */
+	}
+
+	/*
+	 * Since we are finding variables which should be in GROUP BY, there is no
+	 * need to consider pre-existing variables and expressions in the GROUP BY.
+	 */
+
+	if (IsA(node, OpExpr))
+	{
+		OpExpr *op = (OpExpr *) node;
+
+		/* #>> */
+		if (op->opno == 3206)
+		{
+			Node *arg1 = linitial(op->args);
+
+			if (IsA(arg1, FieldSelect))
+			{
+				fselect = (FieldSelect *) arg1;
+				if (!IsA(fselect->arg, Var))
+					return gen_group_exprs_walker((Node *) fselect->arg, ctx);
+
+				var = (Var *) fselect->arg;
+				if ((int) var->varlevelsup != ctx->sublevels_up)
+					return false;
+
+				add_expr_to_group_exprs((Expr *) op, &ctx->group_exprs);
+				return false;
+			}
+
+			if (IsA(arg1, Var))
+			{
+				var = (Var *) arg1;
+				if ((int) var->varlevelsup != ctx->sublevels_up)
+					return false;
+
+				add_expr_to_group_exprs((Expr *) op, &ctx->group_exprs);
+				return false;
+			}
+		}
+
+		return gen_group_exprs_walker((Node *) op->args, ctx);
+	}
+
+	if (IsA(node, EdgeRefRow))
+	{
+		EdgeRefRow *r = (EdgeRefRow *) node;
+
+		if (has_column_in_edgeref (r->arg, ctx->sublevels_up))
+		{
+			add_expr_to_group_exprs((Expr *) r, &ctx->group_exprs);
+			return false;
+		}
+
+		return gen_group_exprs_walker((Node *) r->arg, ctx);
+	}
+
+	if (IsA(node, EdgeRefRows))
+	{
+		EdgeRefRows *r = (EdgeRefRows *) node;
+
+		if (has_column_in_edgeref (r->arg, ctx->sublevels_up))
+		{
+			add_expr_to_group_exprs((Expr *) r, &ctx->group_exprs);
+			return false;
+		}
+		return gen_group_exprs_walker((Node *) r->arg, ctx);
+	}
+
+	if (IsA(node, FieldSelect))
+	{
+		fselect = (FieldSelect *) node;
+
+		/* NOTE: There might be other cases to check. */
+
+		if (!IsA(fselect->arg, Var))
+			return gen_group_exprs_walker((Node *) fselect->arg, ctx);
+
+		var = (Var *) fselect->arg;
+
+		if ((int) var->varlevelsup != ctx->sublevels_up)
+			return false;
+
+		add_expr_to_group_exprs((Expr *) fselect, &ctx->group_exprs);
+		return false;
+	}
+
+	if (IsA(node, Var))
+	{
+		var = (Var *) node;
+
+		if ((int) var->varlevelsup != ctx->sublevels_up)
+			return false;
+
+		add_expr_to_group_exprs((Expr *) var, &ctx->group_exprs);
+		return false;
 	}
 
 	if (IsA(node, Query))
 	{
-		bool		result;
+		bool result;
 
 		ctx->sublevels_up++;
-		result = query_tree_walker((Query *) node, find_agg_walker, ctx, 0);
+		result = query_tree_walker((Query *) node, gen_group_exprs_walker, ctx,
+								   0);
 		ctx->sublevels_up--;
 
 		return result;
 	}
 
-	return expression_tree_walker(node, find_agg_walker, ctx);
-}
-
-static bool
-add_expr_to_group_exprs(Expr *expr, List **group_exprs)
-{
-	ListCell *le;
-
-	/* check duplication */
-	foreach(le, *group_exprs)
-	{
-		Expr	   *gexpr = lfirst(le);
-
-		if (equal(gexpr, expr))
-			return false;
-	}
-
-	*group_exprs = lappend(*group_exprs, expr);
-	return true;
+	return expression_tree_walker(node, gen_group_exprs_walker, ctx);
 }
 
 /*
@@ -3639,94 +3727,62 @@ add_expr_to_group_exprs(Expr *expr, List **group_exprs)
 List *
 generateGroupClause(ParseState *pstate, List **targetlist, List *sortClause)
 {
-	ListCell   *lt;
-	TargetEntry *te;
-	List	   *group_exprs = NIL;
-	ListCell   *le;
 	List	   *group = NIL;
+	gen_group_exprs_context ctx;
+	ListCell   *gl;
 
 	if (!pstate->p_hasAggs)
 		return NIL;
 
-	foreach(lt, *targetlist)
+	ctx.group_exprs = NIL;
+	ctx.sublevels_up = 0;
+	gen_group_exprs_walker((Node *) *targetlist, &ctx);
+
+	foreach(gl, ctx.group_exprs)
 	{
-		find_agg_context factx;
-
-		te = lfirst(lt);
-
-		factx.sublevels_up = 0;
-		if (find_agg_walker((Node *) te->expr, &factx))
-		{
-			if (!IsA(te->expr, Aggref))
-			{
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("aggregate must exist solely"),
-						 parser_errposition(pstate,
-											exprLocation((Node *) te->expr))));
-				return NIL;
-			}
-		}
-		else
-		{
-			find_var_context fvctx;
-
-			/*
-			 * If `te->expr` does not have aggregate functions and
-			 * it is not a constant expression, add it to GROUP BY.
-			 */
-
-			fvctx.sublevels_up = 0;
-			if (find_var_walker((Node *) te->expr, &fvctx))
-				add_expr_to_group_exprs(te->expr, &group_exprs);
-		}
-	}
-
-	foreach(le, group_exprs)
-	{
-		Expr	   *gexpr = lfirst(le);
+		Expr	   *gexpr = (Expr *) lfirst(gl);
+		ListCell   *tl;
+		TargetEntry *tle;
+		ListCell   *sl;
 		bool		done;
-		ListCell   *ls;
 
 		/*
 		 * See findTargetlistEntrySQL99()
 		 */
 
 		/* find the TargetEntry which exactly has this expression */
-		foreach(lt, *targetlist)
+		foreach(tl, *targetlist)
 		{
-			Node	   *expr;
+			Node *texpr;
 
-			te = lfirst(lt);
-
-			expr = strip_implicit_coercions((Node *) te->expr);
-			if (equal(expr, gexpr))
+			tle = (TargetEntry *) lfirst(tl);
+			texpr = strip_implicit_coercions((Node *) tle->expr);
+			if (equal(texpr, gexpr))
 				break;
 		}
 
 		/* not found, make one and add it to the target list */
-		if (lt == NULL)
+		if (tl == NULL)
 		{
-			te = makeTargetEntry(copyObject(gexpr),
-								 (AttrNumber) pstate->p_next_resno++,
-								 NULL, true);
-
-			*targetlist = lappend(*targetlist, te);
+			tle = makeTargetEntry(copyObject(gexpr),
+								  (AttrNumber) pstate->p_next_resno++,
+								  NULL, true);
+			*targetlist = lappend(*targetlist, tle);
 		}
 
 		/*
 		 * See transformGroupClauseExpr()
 		 */
 
-		if (targetIsInSortList(te, InvalidOid, group))
+		if (targetIsInSortList(tle, InvalidOid, group))
 			continue;
 
 		done = false;
-		foreach(ls, sortClause)
+		foreach(sl, sortClause)
 		{
-			SortGroupClause *sc = lfirst(ls);
+			SortGroupClause *sc = (SortGroupClause *) lfirst(sl);
 
-			if (sc->tleSortGroupRef == te->ressortgroupref)
+			if (sc->tleSortGroupRef == tle->ressortgroupref)
 			{
 				group = lappend(group, copyObject(sc));
 				done = true;
@@ -3736,7 +3792,7 @@ generateGroupClause(ParseState *pstate, List **targetlist, List *sortClause)
 		if (done)
 			continue;
 
-		group = addTargetToGroupList(pstate, te, group, *targetlist, -1);
+		group = addTargetToGroupList(pstate, tle, group, *targetlist, -1);
 	}
 
 	return group;

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -1437,52 +1437,54 @@ WITH max(b.id) AS id, x AS x RETURN *;
 EXPLAIN VERBOSE
 MATCH (a:person {id: 1})-[x:knows*1..2]->(b:person)
 WITH max(length(x)) AS x, b.id AS id RETURN *;
-                                                                                       QUERY PLAN                                                                                        
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- HashAggregate  (cost=394.60..396.60 rows=200 width=64)
-   Output: max((length(EDGEREFROWS(x.path)))::numeric), (b.properties.'id'::text)
-   Group Key: b.properties.'id'::text
-   ->  Nested Loop  (cost=200.52..391.24 rows=336 width=64)
-         Output: b.properties.'id'::text, x.path
-         ->  Seq Scan on t.person a  (cost=0.00..25.00 rows=6 width=8)
-               Output: a.id, a.properties
-               Filter: (a.properties.'id'::text = '1'::jsonb)
-         ->  Hash Join  (cost=200.52..227.58 rows=56 width=64)
-               Output: x.path, b.properties
-               Hash Cond: (b.id = x."end")
-               ->  Seq Scan on t.person b  (cost=0.00..22.00 rows=1200 width=40)
-                     Output: b.id, b.properties
-               ->  Hash  (cost=199.82..199.82 rows=56 width=40)
-                     Output: x.path, x."end"
-                     ->  Subquery Scan on x  (cost=0.00..199.82 rows=56 width=40)
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on _  (cost=394.60..398.60 rows=200 width=64)
+   Output: _.x, _.id
+   ->  HashAggregate  (cost=394.60..396.60 rows=200 width=96)
+         Output: max((length(EDGEREFROWS(x.path)))::numeric), b.properties.'id'::text, b.properties
+         Group Key: b.properties
+         ->  Nested Loop  (cost=200.52..391.24 rows=336 width=64)
+               Output: b.properties, x.path
+               ->  Seq Scan on t.person a  (cost=0.00..25.00 rows=6 width=8)
+                     Output: a.id, a.properties
+                     Filter: (a.properties.'id'::text = '1'::jsonb)
+               ->  Hash Join  (cost=200.52..227.58 rows=56 width=64)
+                     Output: x.path, b.properties
+                     Hash Cond: (b.id = x."end")
+                     ->  Seq Scan on t.person b  (cost=0.00..22.00 rows=1200 width=40)
+                           Output: b.id, b.properties
+                     ->  Hash  (cost=199.82..199.82 rows=56 width=40)
                            Output: x.path, x."end"
-                           ->  Nested Loop VLE [1..2]  (cost=0.00..199.26 rows=56 width=106)
-                                 Output: l.start, l."end", (ARRAY[rowid(l.tableoid, l.ctid)]), (ARRAY[(edgeref(0, l.ctid))]), r."end", (rowid(r.tableoid, r.ctid)), (edgeref(0, r.ctid))
-                                 ->  Result  (cost=0.00..24.77 rows=7 width=80)
-                                       Output: l.start, l."end", ARRAY[rowid(l.tableoid, l.ctid)], ARRAY[(edgeref(0, l.ctid))]
-                                       ->  Append  (cost=0.00..24.68 rows=7 width=34)
-                                             ->  Seq Scan on t.knows l  (cost=0.00..2.21 rows=1 width=34)
-                                                   Output: l.start, l."end", l.tableoid, l.ctid, edgeref(0, l.ctid)
-                                                   Filter: (l.start = a.id)
-                                             ->  Seq Scan on t.friendships  (cost=0.00..2.21 rows=1 width=34)
-                                                   Output: friendships.start, friendships."end", friendships.tableoid, friendships.ctid, edgeref(1, friendships.ctid)
-                                                   Filter: (friendships.start = a.id)
-                                             ->  Index Scan using familyship_start_idx on t.familyship  (cost=0.15..20.25 rows=5 width=34)
-                                                   Output: familyship.start, familyship."end", familyship.tableoid, familyship.ctid, edgeref(2, familyship.ctid)
-                                                   Index Cond: (familyship.start = a.id)
-                                 ->  Result  (cost=0.00..24.77 rows=7 width=26)
-                                       Output: r."end", rowid(r.tableoid, r.ctid), (edgeref(0, r.ctid))
-                                       ->  Append  (cost=0.00..24.68 rows=7 width=26)
-                                             ->  Seq Scan on t.knows r  (cost=0.00..2.21 rows=1 width=26)
-                                                   Output: r."end", r.tableoid, r.ctid, edgeref(0, r.ctid)
-                                                   Filter: ($1 = r.start)
-                                             ->  Seq Scan on t.friendships friendships_1  (cost=0.00..2.21 rows=1 width=26)
-                                                   Output: friendships_1."end", friendships_1.tableoid, friendships_1.ctid, edgeref(1, friendships_1.ctid)
-                                                   Filter: ($1 = friendships_1.start)
-                                             ->  Index Scan using familyship_start_idx on t.familyship familyship_1  (cost=0.15..20.25 rows=5 width=26)
-                                                   Output: familyship_1."end", familyship_1.tableoid, familyship_1.ctid, edgeref(2, familyship_1.ctid)
-                                                   Index Cond: ($1 = familyship_1.start)
-(43 rows)
+                           ->  Subquery Scan on x  (cost=0.00..199.82 rows=56 width=40)
+                                 Output: x.path, x."end"
+                                 ->  Nested Loop VLE [1..2]  (cost=0.00..199.26 rows=56 width=106)
+                                       Output: l.start, l."end", (ARRAY[rowid(l.tableoid, l.ctid)]), (ARRAY[(edgeref(0, l.ctid))]), r."end", (rowid(r.tableoid, r.ctid)), (edgeref(0, r.ctid))
+                                       ->  Result  (cost=0.00..24.77 rows=7 width=80)
+                                             Output: l.start, l."end", ARRAY[rowid(l.tableoid, l.ctid)], ARRAY[(edgeref(0, l.ctid))]
+                                             ->  Append  (cost=0.00..24.68 rows=7 width=34)
+                                                   ->  Seq Scan on t.knows l  (cost=0.00..2.21 rows=1 width=34)
+                                                         Output: l.start, l."end", l.tableoid, l.ctid, edgeref(0, l.ctid)
+                                                         Filter: (l.start = a.id)
+                                                   ->  Seq Scan on t.friendships  (cost=0.00..2.21 rows=1 width=34)
+                                                         Output: friendships.start, friendships."end", friendships.tableoid, friendships.ctid, edgeref(1, friendships.ctid)
+                                                         Filter: (friendships.start = a.id)
+                                                   ->  Index Scan using familyship_start_idx on t.familyship  (cost=0.15..20.25 rows=5 width=34)
+                                                         Output: familyship.start, familyship."end", familyship.tableoid, familyship.ctid, edgeref(2, familyship.ctid)
+                                                         Index Cond: (familyship.start = a.id)
+                                       ->  Result  (cost=0.00..24.77 rows=7 width=26)
+                                             Output: r."end", rowid(r.tableoid, r.ctid), (edgeref(0, r.ctid))
+                                             ->  Append  (cost=0.00..24.68 rows=7 width=26)
+                                                   ->  Seq Scan on t.knows r  (cost=0.00..2.21 rows=1 width=26)
+                                                         Output: r."end", r.tableoid, r.ctid, edgeref(0, r.ctid)
+                                                         Filter: ($1 = r.start)
+                                                   ->  Seq Scan on t.friendships friendships_1  (cost=0.00..2.21 rows=1 width=26)
+                                                         Output: friendships_1."end", friendships_1.tableoid, friendships_1.ctid, edgeref(1, friendships_1.ctid)
+                                                         Filter: ($1 = friendships_1.start)
+                                                   ->  Index Scan using familyship_start_idx on t.familyship familyship_1  (cost=0.15..20.25 rows=5 width=26)
+                                                         Output: familyship_1."end", familyship_1.tableoid, familyship_1.ctid, edgeref(2, familyship_1.ctid)
+                                                         Index Cond: ($1 = familyship_1.start)
+(45 rows)
 
 EXPLAIN VERBOSE
 MATCH (a:person {id: 1})-[x:knows*1..2]->(b:person)


### PR DESCRIPTION
After upgrading from AgensGraph 1.2 to 1.3, some query containing aggregate functions no longer works.

revert b8d79d0 and remove conflict.
