### PR TITLE
fix: Return null value on first optional match

### DIFF
--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -733,6 +733,33 @@ ORDER BY n, p, m, q;
  "someone"  |         |          | "somebody" |         | 
 (12 rows)
 
+OPTIONAL MATCH (n:person{name: 'unknown'})
+RETURN N;
+ n 
+---
+ 
+(1 row)
+
+OPTIONAL MATCH (n:person{name: 'unknown'}) MATCH (m:person{name: 'someone'})
+RETURN n, m
+ORDER BY n, m;
+ERROR:  Cypher match clauses cannot follow optional match clauses
+HINT:  Perhaps use a WITH clause between them.
+OPTIONAL MATCH (n:person{name: 'unknown'}) WITH n MATCH (m:person{name: 'someone'})
+RETURN n, m
+ORDER BY n, m;
+ n |               m                
+---+--------------------------------
+   | person[3.1]{"name": "someone"}
+(1 row)
+
+OPTIONAL MATCH (n:person{name: 'unknown'}) WITH n MATCH (m:person{name: 'unknown'})
+RETURN n, m
+ORDER BY n, m;
+ n | m 
+---+---
+(0 rows)
+
 -- Variable Length Relationship
 CREATE GRAPH t;
 SET graph_path = t;

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -248,6 +248,21 @@ RETURN n.name AS n, type(r) AS r, p.name AS p,
        m.name AS m, type(s) AS s, q.name AS q
 ORDER BY n, p, m, q;
 
+OPTIONAL MATCH (n:person{name: 'unknown'})
+RETURN N;
+
+OPTIONAL MATCH (n:person{name: 'unknown'}) MATCH (m:person{name: 'someone'})
+RETURN n, m
+ORDER BY n, m;
+
+OPTIONAL MATCH (n:person{name: 'unknown'}) WITH n MATCH (m:person{name: 'someone'})
+RETURN n, m
+ORDER BY n, m;
+
+OPTIONAL MATCH (n:person{name: 'unknown'}) WITH n MATCH (m:person{name: 'unknown'})
+RETURN n, m
+ORDER BY n, m;
+
 -- Variable Length Relationship
 
 CREATE GRAPH t;


### PR DESCRIPTION
"optional match" occures first of statement work properly now.
"match" after "optional match" without "with" make error.