### PR TITLE
fix: Handle parameters with `UNKNOWNOID` type

### DIFF
--- a/src/backend/parser/parse_cypher_expr.c
+++ b/src/backend/parser/parse_cypher_expr.c
@@ -523,8 +523,15 @@ transformParamRef(ParseState *pstate, ParamRef *pref)
 
 	if (pstate->p_paramref_hook != NULL)
 	{
+		Oid			restype;
+
 		result = (*pstate->p_paramref_hook) (pstate, pref);
-		result = coerce_to_jsonb(pstate, result, "parameter", false);
+		restype = exprType(result);
+		if (restype == UNKNOWNOID)
+			result = coerce_type(pstate, result, restype, JSONBOID, -1,
+								 COERCION_IMPLICIT, COERCE_IMPLICIT_CAST, -1);
+		else
+			result = coerce_to_jsonb(pstate, result, "parameter", false);
 	}
 	else
 	{
@@ -1442,6 +1449,10 @@ coerce_to_jsonb(ParseState *pstate, Node *expr, const char *targetname,
 
 	switch (exprType(expr))
 	{
+		case UNKNOWNOID:
+			elog(ERROR, "coercing UNKNOWNOID to JSONBOID cannot happen");
+			return NULL;
+
 		case GRAPHARRAYIDOID:
 		case GRAPHIDOID:
 		case VERTEXARRAYOID:


### PR DESCRIPTION
Current implementation of `transformParamRef()` in Cypher expression
calls `to_jsonb()` over parameters to convert those parameters to
`jsonb` value.

PostgreSQL cannot decide which function to use for the conversion when
the type of a parameter is `UNKNOWNOID` because there are three
`to_jsonb()` functions. (One for `jsonb` and others for `vertex` and
`edge`.)

Now, `coerce_type()` is called instead of `to_jsonb()` only if the type
of the parameter is `UNKNOWNOID`. This call will change the type to
`JSONBOID`.

When binding the actual parameter value to the parameter, `jsonb_in()`
or `jsonb_recv()` will be called with the value.