### PR TITLE
feat: Print NULL values in `_vertex`, `_edge`, and `graphpath`

### DIFF
--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -38,6 +38,27 @@ SELECT * FROM (RETURN 3 + 4, 'hello' + ' agens') AS _(lucky, greeting);
 (1 row)
 
 --
+-- _vertex, _edge, and graphpath with NULL values
+--
+SELECT ARRAY[NULL, NULL, NULL]::_vertex;
+      array       
+------------------
+ [NULL,NULL,NULL]
+(1 row)
+
+SELECT ARRAY[NULL, NULL]::_edge;
+    array    
+-------------
+ [NULL,NULL]
+(1 row)
+
+SELECT (ARRAY[NULL, NULL, NULL]::_vertex, ARRAY[NULL, NULL]::_edge)::graphpath;
+            row             
+----------------------------
+ [NULL,NULL,NULL,NULL,NULL]
+(1 row)
+
+--
 -- CREATE
 --
 CREATE VLABEL repo;

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -38,6 +38,27 @@ SELECT * FROM (RETURN 3 + 4, 'hello' + ' agens') AS _(lucky, greeting);
 (1 row)
 
 --
+-- zero-length _vertex, _edge, and graphpath
+--
+SELECT ARRAY[]::_vertex;
+ array 
+-------
+ []
+(1 row)
+
+SELECT ARRAY[]::_edge;
+ array 
+-------
+ []
+(1 row)
+
+SELECT (ARRAY[]::_vertex, ARRAY[]::_edge)::graphpath;
+ row 
+-----
+ []
+(1 row)
+
+--
 -- _vertex, _edge, and graphpath with NULL values
 --
 SELECT ARRAY[NULL, NULL, NULL]::_vertex;

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -26,6 +26,14 @@ RETURN (SELECT event FROM history WHERE year = 2016);
 SELECT * FROM (RETURN 3 + 4, 'hello' + ' agens') AS _(lucky, greeting);
 
 --
+-- _vertex, _edge, and graphpath with NULL values
+--
+
+SELECT ARRAY[NULL, NULL, NULL]::_vertex;
+SELECT ARRAY[NULL, NULL]::_edge;
+SELECT (ARRAY[NULL, NULL, NULL]::_vertex, ARRAY[NULL, NULL]::_edge)::graphpath;
+
+--
 -- CREATE
 --
 CREATE VLABEL repo;

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -26,6 +26,14 @@ RETURN (SELECT event FROM history WHERE year = 2016);
 SELECT * FROM (RETURN 3 + 4, 'hello' + ' agens') AS _(lucky, greeting);
 
 --
+-- zero-length _vertex, _edge, and graphpath
+--
+
+SELECT ARRAY[]::_vertex;
+SELECT ARRAY[]::_edge;
+SELECT (ARRAY[]::_vertex, ARRAY[]::_edge)::graphpath;
+
+--
 -- _vertex, _edge, and graphpath with NULL values
 --
 


### PR DESCRIPTION
When printing out `_vertex`, `_edge`, and `graphpath`, there is an
`Assert()` for NULL values in them. This commit removes it and modifies
the output functions of them, so that they print out `NULL` for NULL
values.