### PR TITLE
fix: Create a label that does not exist while running CREATE clause

### DIFF
--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -5331,7 +5331,7 @@ createLabelIfNotExist(ParseState *pstate, char *labname, int labloc,
 	else
 		keyword = "ELABEL";
 
-	snprintf(sqlcmd, sizeof(sqlcmd), "CREATE %s %s", keyword, labname);
+	snprintf(sqlcmd, sizeof(sqlcmd), "CREATE %s \"%s\"", keyword, labname);
 
 	if (SPI_connect() != SPI_OK_CONNECT)
 		elog(ERROR, "SPI_connect failed");


### PR DESCRIPTION
The label name is not properly quoted. If the label has some characters
that are not suitable for unquoted identifier, the parsing of the label
creation query fails.