### PR TITLE
Added installation step for RHEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Building from the Source Code
         $ dnf install gcc glibc bison flex readline readline-devel zlib zlib-devel
         ```
 
+    * RHEL:
+        ```sh
+        $ yum install gcc glibc glib-common readline readline-devel zlib zlib-devel flex bison
+        ```
+
     * Ubuntu:
         ```sh
         $ sudo apt-get install build-essential libreadline-dev zlib1g-dev flex bison


### PR DESCRIPTION
I added an installation step for RedHat Enterprise Linux 7 to the manual. I built Agensgraph successfully today on such a system, but it seems flex and bison must be installed, but this step was missing. This maybe even affects Centos,but I haven't tried yet.