### PR TITLE
feat: Make all built-in functions usable

### DIFF
--- a/src/backend/executor/execExpr.c
+++ b/src/backend/executor/execExpr.c
@@ -72,6 +72,8 @@ static bool isAssignmentIndirectionExpr(Expr *expr);
 static void ExecInitCoerceToDomain(ExprEvalStep *scratch, CoerceToDomain *ctest,
 					   PlanState *parent, ExprState *state,
 					   Datum *resv, bool *resnull);
+static void ExecInitCypherTypeCast(ExprEvalStep *scratch, CypherTypeCast *tc,
+								   PlanState *parent, ExprState *state);
 static void ExecInitCypherMap(ExprEvalStep *scratch, CypherMapExpr *mapexpr,
 							  PlanState *parent, ExprState *state);
 static void ExecInitCypherList(ExprEvalStep *scratch, CypherListExpr *listexpr,
@@ -2042,6 +2044,14 @@ ExecInitExprRec(Expr *node, PlanState *parent, ExprState *state,
 				break;
 			}
 
+		case T_CypherTypeCast:
+			{
+				CypherTypeCast *tc = (CypherTypeCast *) node;
+
+				ExecInitCypherTypeCast(&scratch, tc, parent, state);
+				break;
+			}
+
 		case T_CypherMapExpr:
 			{
 				CypherMapExpr *mapexpr = (CypherMapExpr *) node;
@@ -2754,6 +2764,45 @@ ExecInitCoerceToDomain(ExprEvalStep *scratch, CoerceToDomain *ctest,
 				break;
 		}
 	}
+}
+
+static void
+ExecInitCypherTypeCast(ExprEvalStep *scratch, CypherTypeCast *tc,
+					   PlanState *parent, ExprState *state)
+{
+	FmgrInfo   *finfo_in;
+	FunctionCallInfo fcinfo_data_in;
+	Oid			infunc;
+	Oid			typinparam;
+
+	Assert(exprType((Node *) tc->arg) == JSONBOID);
+
+	ExecInitExprRec(tc->arg, parent, state,
+					scratch->resvalue, scratch->resnull);
+
+	finfo_in = palloc0(sizeof(FmgrInfo));
+	fcinfo_data_in = palloc0(sizeof(FunctionCallInfoData));
+
+	getTypeInputInfo(tc->type, &infunc, &typinparam);
+
+	fmgr_info(infunc, finfo_in);
+	fmgr_info_set_expr((Node *) tc, finfo_in);
+
+	InitFunctionCallInfoData(*fcinfo_data_in, finfo_in, 3, InvalidOid,
+							 NULL, NULL);
+
+	/*
+	 * The datum for the first argument will be filled every time when this
+	 * expression is executed by calling ExecEvalCypherTypeCast().
+	 */
+	fcinfo_data_in->arg[1] = ObjectIdGetDatum(typinparam);
+	fcinfo_data_in->argnull[1] = false;
+	fcinfo_data_in->arg[2] = Int32GetDatum(-1);
+	fcinfo_data_in->argnull[2] = false;
+
+	scratch->opcode = EEOP_CYPHERTYPECAST;
+	scratch->d.cyphertypecast.fcinfo_data_in = fcinfo_data_in;
+	ExprEvalPushStep(state, scratch);
 }
 
 static void

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2194,6 +2194,19 @@ _copyOnConflictExpr(const OnConflictExpr *from)
 	return newnode;
 }
 
+static CypherTypeCast *
+_copyCypherTypeCast(const CypherTypeCast *from)
+{
+	CypherTypeCast *newnode = makeNode(CypherTypeCast);
+
+	COPY_SCALAR_FIELD(type);
+	COPY_SCALAR_FIELD(cform);
+	COPY_NODE_FIELD(arg);
+	COPY_LOCATION_FIELD(location);
+
+	return newnode;
+}
+
 static CypherMapExpr *
 _copyCypherMapExpr(const CypherMapExpr *from)
 {
@@ -5504,6 +5517,9 @@ copyObjectImpl(const void *from)
 			break;
 		case T_OnConflictExpr:
 			retval = _copyOnConflictExpr(from);
+			break;
+		case T_CypherTypeCast:
+			retval = _copyCypherTypeCast(from);
 			break;
 		case T_CypherMapExpr:
 			retval = _copyCypherMapExpr(from);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -818,6 +818,17 @@ _equalOnConflictExpr(const OnConflictExpr *a, const OnConflictExpr *b)
 }
 
 static bool
+_equalCypherTypeCast(const CypherTypeCast *a, const CypherTypeCast *b)
+{
+	COMPARE_SCALAR_FIELD(type);
+	COMPARE_COERCIONFORM_FIELD(cform);
+	COMPARE_NODE_FIELD(arg);
+	COMPARE_LOCATION_FIELD(location);
+
+	return true;
+}
+
+static bool
 _equalCypherMapExpr(const CypherMapExpr *a, const CypherMapExpr *b)
 {
 	COMPARE_NODE_FIELD(keyvals);
@@ -3527,6 +3538,9 @@ equal(const void *a, const void *b)
 			break;
 		case T_JoinExpr:
 			retval = _equalJoinExpr(a, b);
+			break;
+		case T_CypherTypeCast:
+			retval = _equalCypherTypeCast(a, b);
 			break;
 		case T_CypherMapExpr:
 			retval = _equalCypherMapExpr(a, b);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1748,6 +1748,17 @@ _outOnConflictExpr(StringInfo str, const OnConflictExpr *node)
 }
 
 static void
+_outCypherTypeCast(StringInfo str, const CypherTypeCast *node)
+{
+	WRITE_NODE_TYPE("CYPHERTYPECAST");
+
+	WRITE_OID_FIELD(type);
+	WRITE_ENUM_FIELD(cform, CoercionForm);
+	WRITE_NODE_FIELD(arg);
+	WRITE_LOCATION_FIELD(location);
+}
+
+static void
 _outCypherMapExpr(StringInfo str, const CypherMapExpr *node)
 {
 	WRITE_NODE_TYPE("CYPHERMAPEXPR");
@@ -4350,6 +4361,9 @@ outNode(StringInfo str, const void *obj)
 				break;
 			case T_OnConflictExpr:
 				_outOnConflictExpr(str, obj);
+				break;
+			case T_CypherTypeCast:
+				_outCypherTypeCast(str, obj);
 				break;
 			case T_CypherMapExpr:
 				_outCypherMapExpr(str, obj);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2522,6 +2522,19 @@ _readCypherListComp(void)
 	READ_DONE();
 }
 
+static CypherTypeCast *
+_readCypherTypeCast(void)
+{
+	READ_LOCALS(CypherTypeCast);
+
+	READ_OID_FIELD(type);
+	READ_ENUM_FIELD(cform, CoercionForm);
+	READ_NODE_FIELD(arg);
+	READ_LOCATION_FIELD(location);
+
+	READ_DONE();
+}
+
 static CypherMapExpr *
 _readCypherMapExpr(void)
 {
@@ -2886,6 +2899,8 @@ parseNodeString(void)
 		return_value = _readGraphDelElem();
 	else if (MATCH("CYPHERLISTCOMP", 14))
 		return_value = _readCypherListComp();
+	else if (MATCH("CYPHERTYPECAST", 14))
+		return_value = _readCypherTypeCast();
 	else if (MATCH("CYPHERMAPEXPR", 13))
 		return_value = _readCypherMapExpr();
 	else if (MATCH("CYPHERLISTEXPR", 14))

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -3572,6 +3572,28 @@ eval_const_expressions_mutator(Node *node,
 													  context);
 			}
 			break;
+		case T_CypherTypeCast:
+			{
+				CypherTypeCast *tc = (CypherTypeCast *) node;
+				Node	   *newarg;
+				CypherTypeCast *newtc;
+
+				newarg = eval_const_expressions_mutator((Node *) tc->arg,
+														context);
+
+				newtc = makeNode(CypherTypeCast);
+				newtc->type = tc->type;
+				newtc->cform = tc->cform;
+				newtc->arg = (Expr *) newarg;
+				newtc->location = tc->location;
+
+				if (IsA(newarg, Const))
+					return (Node *) evaluate_expr((Expr *) newtc, newtc->type,
+												  -1, InvalidOid);
+
+				return (Node *) newtc;
+			}
+			break;
 		case T_CypherMapExpr:
 			{
 				CypherMapExpr *m = (CypherMapExpr *) node;
@@ -3605,6 +3627,7 @@ eval_const_expressions_mutator(Node *node,
 
 				newm = makeNode(CypherMapExpr);
 				newm->keyvals = newkeyvals;
+				newm->location = m->location;
 
 				/* it is safe to reduce this CypherMapExpr */
 				if (all_const)
@@ -3635,6 +3658,7 @@ eval_const_expressions_mutator(Node *node,
 
 				newcl = makeNode(CypherListExpr);
 				newcl->elems = newelems;
+				newcl->location = cl->location;
 
 				if (all_const)
 					return (Node *) evaluate_expr((Expr *) newcl, JSONBOID, -1,
@@ -3652,6 +3676,7 @@ eval_const_expressions_mutator(Node *node,
 				newclc->varname = pstrdup(clc->varname);
 				newclc->cond = clc->cond;
 				newclc->elem = clc->elem;
+				newclc->location = clc->location;
 				return (Node *) newclc;
 			}
 		case T_CypherAccessExpr:

--- a/src/backend/utils/adt/cypher_ops.c
+++ b/src/backend/utils/adt/cypher_ops.c
@@ -436,50 +436,12 @@ jsonb_num(Jsonb *j, PGFunction f)
 }
 
 Datum
-jsonb_graphid(PG_FUNCTION_ARGS)
+numeric_graphid(PG_FUNCTION_ARGS)
 {
-	Jsonb	   *j = PG_GETARG_JSONB(0);
+	Datum		n = PG_GETARG_DATUM(0);
+	Datum		d;
 
-	if (JB_ROOT_IS_SCALAR(j))
-	{
-		JsonbValue *jv;
+	d = DirectFunctionCall1(numeric_out, n);
 
-		jv = getIthJsonbValueFromContainer(&j->root, 0);
-		switch (jv->type)
-		{
-			case jbvNull:
-			case jbvBool:
-				break;
-			case jbvString:
-				{
-					Size		sz;
-					char	   *buf;
-
-					sz = sizeof(char) * (jv->val.string.len + 1);
-					buf = (char *) palloc(sz);
-
-					strncpy(buf, jv->val.string.val, jv->val.string.len);
-					buf[jv->val.string.len] = '\0';
-
-					PG_RETURN_DATUM(DirectFunctionCall1(graphid_in,
-														CStringGetDatum(buf)));
-				}
-			case jbvNumeric:
-				{
-					Datum		d;
-
-					d = DirectFunctionCall1(numeric_out,
-											NumericGetDatum(jv->val.numeric));
-
-					PG_RETURN_DATUM(DirectFunctionCall1(graphid_in, d));
-				}
-			default:
-				elog(ERROR, "unknown jsonb scalar type");
-		}
-	}
-
-	ereport(ERROR,
-			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-			 errmsg("%s cannot be converted to graphid",
-					JsonbToCString(NULL, &j->root, VARSIZE(j)))));
+	PG_RETURN_DATUM(DirectFunctionCall1(graphid_in, d));
 }

--- a/src/include/catalog/pg_cast.h
+++ b/src/include/catalog/pg_cast.h
@@ -407,7 +407,7 @@ DATA(insert ( 3802   23 7194 a f ));
 DATA(insert ( 3802 1700 7195 e f ));
 DATA(insert ( 3802  701 7196 e f ));
 
-/* implicit coercion from jsonb to graphid */
-DATA(insert ( 3802 7002 7245 i f ));
+/* implicit coercion from numeric to graphid */
+DATA(insert ( 1700 7002 7245 i f ));
 
 #endif							/* PG_CAST_H */

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5711,9 +5711,9 @@ DATA(insert OID = 7243 ( string_contains	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 
 DESCR("true if LHS contains RHS");
 DATA(insert OID = 7244 ( string_regex		PGNSP PGUID 12 1 0 0 0 f f f f t f i s 2 0 16 "3802 3802" _null_ _null_ _null_ _null_ _null_ jsonb_string_regex _null_ _null_ _null_ ));
 DESCR("true if regex match");
-/* Cypher expressions - coercion from jsonb to graphid */
-DATA(insert OID = 7245 ( graphid	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 7002 "3802" _null_ _null_ _null_ _null_ _null_ jsonb_graphid _null_ _null_ _null_ ));
-DESCR("convert jsonb to graphid");
+/* Cypher expressions - coercion from numeric to graphid */
+DATA(insert OID = 7245 ( graphid	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 7002 "1700" _null_ _null_ _null_ _null_ _null_ numeric_graphid _null_ _null_ _null_ ));
+DESCR("convert numeric to graphid");
 
 /*
  * Symbolic values for provolatile column: these indicate whether the result

--- a/src/include/executor/execExpr.h
+++ b/src/include/executor/execExpr.h
@@ -214,6 +214,7 @@ typedef enum ExprEvalOp
 	EEOP_SUBPLAN,
 	EEOP_ALTERNATIVE_SUBPLAN,
 
+	EEOP_CYPHERTYPECAST,
 	EEOP_CYPHERMAPEXPR,
 	EEOP_CYPHERLISTEXPR,
 	EEOP_CYPHERLISTCOMP_BEGIN,
@@ -575,6 +576,11 @@ typedef struct ExprEvalStep
 
 		struct
 		{
+			FunctionCallInfo fcinfo_data_in;
+		}			cyphertypecast;
+
+		struct
+		{
 			char	  **key_cstrings;
 			Datum	   *val_values;
 			bool	   *val_nulls;
@@ -724,6 +730,7 @@ extern void ExecEvalAlternativeSubPlan(ExprState *state, ExprEvalStep *op,
 						   ExprContext *econtext);
 extern void ExecEvalWholeRowVar(ExprState *state, ExprEvalStep *op,
 					ExprContext *econtext);
+extern void ExecEvalCypherTypeCast(ExprState *state, ExprEvalStep *op);
 extern void ExecEvalCypherMapExpr(ExprState *state, ExprEvalStep *op);
 extern void ExecEvalCypherListExpr(ExprState *state, ExprEvalStep *op);
 extern void ExecEvalCypherAccessExpr(ExprState *state, ExprEvalStep *op);

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -200,6 +200,7 @@ typedef enum NodeTag
 	T_FromExpr,
 	T_OnConflictExpr,
 	T_IntoClause,
+	T_CypherTypeCast,
 	T_CypherMapExpr,
 	T_CypherListExpr,
 	T_CypherListCompExpr,

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -1505,6 +1505,15 @@ typedef struct OnConflictExpr
  * Cypher Query Language
  */
 
+typedef struct CypherTypeCast
+{
+	Expr		xpr;
+	Oid			type;
+	CoercionForm cform;
+	Expr	   *arg;
+	int			location;
+} CypherTypeCast;
+
 typedef struct CypherMapExpr
 {
 	Expr		xpr;

--- a/src/include/parser/parse_cypher_expr.h
+++ b/src/include/parser/parse_cypher_expr.h
@@ -21,6 +21,11 @@ extern Node *transformCypherExpr(ParseState *pstate, Node *expr,
 extern Node *transformCypherMapForSet(ParseState *pstate, Node *expr,
 									  List **pathelems, char **varname);
 
+/* coerce functions */
+extern Node *coerce_expr(ParseState *pstate, Node *expr, Oid ityp, Oid otyp,
+						 int32 otypmod, CoercionContext cctx,
+						 CoercionForm cform, int loc);
+
 /* clause functions */
 extern Node *transformCypherWhere(ParseState *pstate, Node *clause,
 								  ParseExprKind exprKind);
@@ -33,6 +38,7 @@ extern List *transformCypherOrderBy(ParseState *pstate, List *orderlist,
 /* item list functions */
 extern List *transformItemList(ParseState *pstate, List *items,
 							   ParseExprKind exprKind);
+extern void resolveItemList(ParseState *pstate, List *items);
 extern List *transformCypherExprList(ParseState *pstate, List *exprlist,
 									 ParseExprKind exprKind);
 

--- a/src/include/utils/cypher_ops.h
+++ b/src/include/utils/cypher_ops.h
@@ -32,7 +32,7 @@ extern Datum jsonb_int4(PG_FUNCTION_ARGS);
 extern Datum jsonb_numeric(PG_FUNCTION_ARGS);
 extern Datum jsonb_float8(PG_FUNCTION_ARGS);
 
-/* coercion from jsonb to graphid */
-extern Datum jsonb_graphid(PG_FUNCTION_ARGS);
+/* coercion from numeric to graphid */
+extern Datum numeric_graphid(PG_FUNCTION_ARGS);
 
 #endif	/* CYPHER_OPS_H */

--- a/src/test/regress/expected/cypher_ddl.out
+++ b/src/test/regress/expected/cypher_ddl.out
@@ -740,7 +740,7 @@ CREATE CONSTRAINT ON regv4 ASSERT (length(password) > 8 AND length(password) < 1
 Vertex label "ddl.regv4"
 --
 Constraints:
-    "regv4_properties_check" ASSERT (length(password) > 8 AND length(password) < 16)
+    "regv4_properties_check" ASSERT (length(password) > to_jsonb(8) AND length(password) < to_jsonb(16))
 Inherits: ddl.ag_vertex
 
 CREATE (:regv4 {password: '12345678'});
@@ -837,7 +837,7 @@ CREATE CONSTRAINT ON regv7 ASSERT a.b[0].c IS NOT NULL;
 Vertex label "ddl.regv7"
 --
 Constraints:
-    "regv7_properties_check" ASSERT ((a.b[0].c) IS NOT NULL)
+    "regv7_properties_check" ASSERT ((a.b[to_jsonb(0)].c) IS NOT NULL)
 Inherits: ddl.ag_vertex
 
 CREATE (:regv7 {a: {b: [{c: 'd'}, {c: 'e'}]}});
@@ -849,7 +849,7 @@ CREATE VLABEL regv8;
 CREATE CONSTRAINT ON regv8 ASSERT (SELECT * FROM graph.regv8).c IS NOT NULL;
 ERROR:  cannot use subquery in check constraint
 CREATE CONSTRAINT ON regv8 ASSERT (1).c IS NOT NULL;
-ERROR:  map or list is expected but scalar value
+ERROR:  map or list is expected but integer
 CREATE CONSTRAINT ON regv8 ASSERT ($1).c IS NOT NULL;
 ERROR:  there is no parameter $1
 --

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -16,13 +16,13 @@ CREATE GRAPH agens;
 RETURN 3 + 4, 'hello' + ' agens';
  ?column? |   ?column?    
 ----------+---------------
- 7        | "hello agens"
+        7 | "hello agens"
 (1 row)
 
 RETURN 3 + 4 AS lucky, 'hello' + ' agens' AS greeting;
  lucky |   greeting    
 -------+---------------
- 7     | "hello agens"
+     7 | "hello agens"
 (1 row)
 
 RETURN (SELECT event FROM history WHERE year = 2016);
@@ -34,7 +34,7 @@ RETURN (SELECT event FROM history WHERE year = 2016);
 SELECT * FROM (RETURN 3 + 4, 'hello' + ' agens') AS _(lucky, greeting);
  lucky |   greeting    
 -------+---------------
- 7     | "hello agens"
+     7 | "hello agens"
 (1 row)
 
 --
@@ -1380,7 +1380,7 @@ WITH x[0] AS x1, x[1] AS x2 ORDER BY x2 RETURN x1;
                Output: x.edges[1], x.edges[2]
                ->  Seq Scan on t.person a
                      Output: a.id, a.properties
-                     Filter: (a.properties.'id'::text = '1'::jsonb)
+                     Filter: (a.properties.'id'::text = to_jsonb(1))
                ->  Hash Join
                      Output: x.edges
                      Hash Cond: (b.id = x."end")
@@ -1420,7 +1420,7 @@ WITH x[0] AS x1, x[1] AS x2 ORDER BY x2 RETURN x1;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 MATCH (a:person {id: 1})-[x:knows*1..2]->(b:person)
-WITH max(b.id) AS id, x[0] AS x RETURN *;
+WITH max(b.id::"numeric") AS id, x[0] AS x RETURN *;
                                                                                                                                              QUERY PLAN                                                                                                                                              
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -1433,7 +1433,7 @@ WITH max(b.id) AS id, x[0] AS x RETURN *;
                Output: x.edges[1], b.properties
                ->  Seq Scan on t.person a
                      Output: a.id, a.properties
-                     Filter: (a.properties.'id'::text = '1'::jsonb)
+                     Filter: (a.properties.'id'::text = to_jsonb(1))
                ->  Hash Join
                      Output: x.edges, b.properties
                      Hash Cond: (b.id = x."end")
@@ -1485,7 +1485,7 @@ WITH DISTINCT x AS path RETURN *;
                Output: x.edges
                ->  Seq Scan on t.person a
                      Output: a.id, a.properties
-                     Filter: (a.properties.'id'::text = '1'::jsonb)
+                     Filter: (a.properties.'id'::text = to_jsonb(1))
                ->  Hash Join
                      Output: x.edges
                      Hash Cond: (b.id = x."end")
@@ -1525,7 +1525,7 @@ WITH DISTINCT x AS path RETURN *;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 MATCH (a:person {id: 1})-[x:knows*1..2]->(b:person)
-WITH max(b.id) AS id, x AS x RETURN *;
+WITH max(b.id::"numeric") AS id, x AS x RETURN *;
                                                                                                                                              QUERY PLAN                                                                                                                                              
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
@@ -1538,7 +1538,7 @@ WITH max(b.id) AS id, x AS x RETURN *;
                Output: x.edges, b.properties
                ->  Seq Scan on t.person a
                      Output: a.id, a.properties
-                     Filter: (a.properties.'id'::text = '1'::jsonb)
+                     Filter: (a.properties.'id'::text = to_jsonb(1))
                ->  Hash Join
                      Output: x.edges, b.properties
                      Hash Cond: (b.id = x."end")
@@ -1578,7 +1578,7 @@ WITH max(b.id) AS id, x AS x RETURN *;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 MATCH (a:person {id: 1})-[x:knows*1..2]->(b:person)
-WITH max(length(x)) AS x, b.id AS id RETURN *;
+WITH max(length(x)::"numeric") AS x, b.id AS id RETURN *;
                                                                                                                                           QUERY PLAN                                                                                                                                           
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  HashAggregate
@@ -1588,7 +1588,7 @@ WITH max(length(x)) AS x, b.id AS id RETURN *;
          Output: b.properties.'id'::text, x.edges
          ->  Seq Scan on t.person a
                Output: a.id, a.properties
-               Filter: (a.properties.'id'::text = '1'::jsonb)
+               Filter: (a.properties.'id'::text = to_jsonb(1))
          ->  Hash Join
                Output: x.edges, b.properties
                Hash Cond: (b.id = x."end")
@@ -1635,7 +1635,7 @@ RETURN x, x IS NOT NULL, x[0] IS NULL;
    Output: x.edges, (x.edges IS NOT NULL), (x.edges[1] IS NOT DISTINCT FROM NULL)
    ->  Seq Scan on t.person a
          Output: a.id, a.properties
-         Filter: (a.properties.'id'::text = '1'::jsonb)
+         Filter: (a.properties.'id'::text = to_jsonb(1))
    ->  Hash Join
          Output: x.edges
          Hash Cond: (b.id = x."end")
@@ -1682,7 +1682,7 @@ WHERE x[0] IS NOT NULL RETURN x[0];
    Output: x.edges[1]
    ->  Seq Scan on t.person a
          Output: a.id, a.properties
-         Filter: (a.properties.'id'::text = '1'::jsonb)
+         Filter: (a.properties.'id'::text = to_jsonb(1))
    ->  Hash Join
          Output: x.edges
          Hash Cond: (b.id = x."end")
@@ -1736,7 +1736,7 @@ SELECT * FROM (
          Output: x.edges[1]
          ->  Seq Scan on t.person a
                Output: a.id, a.properties
-               Filter: (a.properties.'id'::text = '1'::jsonb)
+               Filter: (a.properties.'id'::text = to_jsonb(1))
          ->  Hash Join
                Output: x.edges
                Hash Cond: (b.id = x."end")
@@ -1777,7 +1777,7 @@ SELECT * FROM (
          Output: x_1.edges[2]
          ->  Seq Scan on t.person a_1
                Output: a_1.id, a_1.properties
-               Filter: (a_1.properties.'id'::text = '1'::jsonb)
+               Filter: (a_1.properties.'id'::text = to_jsonb(1))
          ->  Hash Join
                Output: x_1.edges
                Hash Cond: (b_1.id = x_1."end")

--- a/src/test/regress/expected/cypher_expr.out
+++ b/src/test/regress/expected/cypher_expr.out
@@ -4,18 +4,100 @@
 -- Set up
 CREATE GRAPH test_cypher_expr;
 SET graph_path = test_cypher_expr;
--- Numeric, string, and boolean literal
-RETURN '"', '\"', '\\"', 17, true, false;
- ?column? | ?column? | ?column? | ?column? | bool | bool 
-----------+----------+----------+----------+------+------
- "\""     | "\""     | "\\\""   | 17       | t    | f
+-- String (jsonb)
+RETURN '"', '\"', '\\', '\/', '\b', '\f', '\n', '\r', '\t';
+ ?column? | ?column? | ?column? | ?column? | ?column? | ?column? | ?column? | ?column? | ?column? 
+----------+----------+----------+----------+----------+----------+----------+----------+----------
+ "\""     | "\""     | "\\"     | "/"      | "\b"     | "\f"     | "\n"     | "\r"     | "\t"
 (1 row)
 
--- Octal and hexadecimal literal
-RETURN 021, 0x11, 0X11;
- ?column? | ?column? | ?column? 
-----------+----------+----------
- 17       | 17       | 17
+-- Decimal (int4, int8, numeric)
+RETURN -2147483648, 2147483647;
+  ?column?   |  ?column?  
+-------------+------------
+ -2147483648 | 2147483647
+(1 row)
+
+RETURN -9223372036854775808, 9223372036854775807;
+       ?column?       |      ?column?       
+----------------------+---------------------
+ -9223372036854775808 | 9223372036854775807
+(1 row)
+
+RETURN -9223372036854775809, 9223372036854775808;
+       ?column?       |      ?column?       
+----------------------+---------------------
+ -9223372036854775809 | 9223372036854775808
+(1 row)
+
+-- Hexadecimal (int4)
+RETURN -0x7fffffff, 0x7fffffff;
+  ?column?   |  ?column?  
+-------------+------------
+ -2147483647 | 2147483647
+(1 row)
+
+-- Octal (int4)
+RETURN -017777777777, 017777777777;
+  ?column?   |  ?column?  
+-------------+------------
+ -2147483647 | 2147483647
+(1 row)
+
+-- Float (numeric)
+RETURN 3.14, -3.14, 6.02E23;
+ ?column? | ?column? |         ?column?         
+----------+----------+--------------------------
+     3.14 |    -3.14 | 602000000000000000000000
+(1 row)
+
+-- true, false, null
+RETURN true, false, null;
+ bool | bool | ?column? 
+------+------+----------
+ t    | f    | 
+(1 row)
+
+-- String (text)
+RETURN '"'::text, '\"'::text, '\\'::text, '\/'::text,
+       '\b'::text, '\f'::text, '\n'::text, '\r'::text, '\t'::text;
+ text | text | text | text | text | text | text | text |   text   
+------+------+------+------+------+------+------+------+----------
+ "    | "    | \    | /    | \x08 | \x0C |     +| \r   |         
+      |      |      |      |      |      |      |      | 
+(1 row)
+
+-- Parameter - UNKNOWNOID::jsonb (string)
+PREPARE tmp AS RETURN $1;
+EXECUTE tmp ('"\""');
+ ?column? 
+----------
+ "\""
+(1 row)
+
+DEALLOCATE tmp;
+-- Parameter - UNKNOWNOID::text
+PREPARE tmp AS RETURN $1::text;
+EXECUTE tmp ('\"');
+ text 
+------
+ \"
+(1 row)
+
+DEALLOCATE tmp;
+-- ::bool
+RETURN ''::jsonb::bool, 0::jsonb::bool, false::jsonb::bool,
+       []::bool, {}::bool;
+ bool | bool | bool | bool | bool 
+------+------+------+------+------
+ f    | f    | f    | f    | f
+(1 row)
+
+RETURN 's'::jsonb::bool, 1::jsonb::bool, true::jsonb::bool,
+       [0]::bool, {p: 0}::bool;
+ bool | bool | bool | bool | bool 
+------+------+------+------+------
+ t    | t    | t    | t    | t
 (1 row)
 
 -- List and map literal
@@ -43,7 +125,7 @@ RETURN '1' + '1', '1' + 1, 1 + '1';
 RETURN 1 + 1, 1 - 1, 2 * 2, 2 / 2, 2 % 2, 2 ^ 2, +1, -1;
  ?column? | ?column? | ?column? | ?column? | ?column? | ?column? | ?column? | ?column? 
 ----------+----------+----------+----------+----------+----------+----------+----------
- 2        | 0        | 4        | 1        | 0        | 4        | 1        | -1
+        2 |        0 |        4 |        1 |        0 | 4        |        1 |       -1
 (1 row)
 
 -- List concatenation
@@ -634,12 +716,21 @@ MATCH (n:coll) RETURN n;
  coll[5.1]{"l": "agensgraph", "u": "AGENSGRAPH", "name": "AgensGraph"}
 (1 row)
 
+-- Text matching
+CREATE (:ts {v: 'a fat cat sat on a mat and ate a fat rat'::tsvector});
+MATCH (n:ts) WHERE n.v::tsvector @@ 'cat & rat'::tsquery RETURN n;
+                                 n                                  
+--------------------------------------------------------------------
+ ts[6.1]{"v": "'a' 'and' 'ate' 'cat' 'fat' 'mat' 'on' 'rat' 'sat'"}
+(1 row)
+
 -- Tear down
 DROP GRAPH test_cypher_expr CASCADE;
-NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to sequence test_cypher_expr.ag_label_seq
 drop cascades to vlabel ag_vertex
 drop cascades to elabel ag_edge
 drop cascades to vlabel v0
 drop cascades to vlabel v1
 drop cascades to vlabel coll
+drop cascades to vlabel ts

--- a/src/test/regress/expected/graphid.out
+++ b/src/test/regress/expected/graphid.out
@@ -51,14 +51,14 @@ SELECT '65536.281474976710655'::graphid;
 ERROR:  labid out of range
 LINE 1: SELECT '65536.281474976710655'::graphid;
                ^
--- Coercion from jsonb to graphid
-SELECT '"1.1"'::jsonb::graphid;
+-- Coercion from unknown and numeric to graphid
+SELECT '1.1'::graphid;
  graphid 
 ---------
  1.1
 (1 row)
 
-SELECT '1.1'::jsonb::graphid;
+SELECT 1.1::graphid;
  graphid 
 ---------
  1.1

--- a/src/test/regress/serial_schedule
+++ b/src/test/regress/serial_schedule
@@ -181,6 +181,7 @@ test: event_trigger
 test: stats
 test: graphid
 test: graphmeta
+test: cypher_ddl
 test: cypher_expr
 test: cypher_dml
 test: cypher_shortestpath
@@ -188,5 +189,4 @@ test: cypher_eager
 test: cypher_func
 test: cypher_plpgsql
 test: sql_restriction
-test: cypher_ddl
 test: propertyindex

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -468,7 +468,7 @@ WITH x[0] AS x1, x[1] AS x2 ORDER BY x2 RETURN x1;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 MATCH (a:person {id: 1})-[x:knows*1..2]->(b:person)
-WITH max(b.id) AS id, x[0] AS x RETURN *;
+WITH max(b.id::"numeric") AS id, x[0] AS x RETURN *;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 MATCH (a:person {id: 1})-[x:knows*1..2]->(b:person)
@@ -476,11 +476,11 @@ WITH DISTINCT x AS path RETURN *;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 MATCH (a:person {id: 1})-[x:knows*1..2]->(b:person)
-WITH max(b.id) AS id, x AS x RETURN *;
+WITH max(b.id::"numeric") AS id, x AS x RETURN *;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 MATCH (a:person {id: 1})-[x:knows*1..2]->(b:person)
-WITH max(length(x)) AS x, b.id AS id RETURN *;
+WITH max(length(x)::"numeric") AS x, b.id AS id RETURN *;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 MATCH (a:person {id: 1})-[x:knows*1..2]->(b:person)

--- a/src/test/regress/sql/graphid.sql
+++ b/src/test/regress/sql/graphid.sql
@@ -20,10 +20,10 @@ SELECT '65535.281474976710655'::graphid;
 SELECT '65535.281474976710656'::graphid;
 SELECT '65536.281474976710655'::graphid;
 
--- Coercion from jsonb to graphid
+-- Coercion from unknown and numeric to graphid
 
-SELECT '"1.1"'::jsonb::graphid;
-SELECT '1.1'::jsonb::graphid;
+SELECT '1.1'::graphid;
+SELECT 1.1::graphid;
 
 -- Insert and Operator
 


### PR DESCRIPTION
* Change the implementation of constants
  * Handle `UNKNOWNOID` constants properly (::jsonb and ::text)
  * Handle parameters AS-IS
* Implement type casting
  * Implement pre-evaluating `CypherTypeCast`
  * Implement auto type casting on function call
  * Implement auto type casting on operators
  * `jsonb` to `graphid` -> `numeric` to `graphid`
* Change `EQUALS_TILDE` to `EQUAL_TILDE`
* Update comment about token precedence in gram.y