### PR TITLE
fix: Make `=` operator with vertices work for hash join

### DIFF
--- a/src/backend/utils/adt/graph.c
+++ b/src/backend/utils/adt/graph.c
@@ -216,8 +216,8 @@ graph_labid(PG_FUNCTION_ARGS)
 static int
 graphid_cmp(FunctionCallInfo fcinfo)
 {
-	Graphid	   id1 = PG_GETARG_GRAPHID(0);
-	Graphid	   id2 = PG_GETARG_GRAPHID(1);
+	Graphid		id1 = PG_GETARG_GRAPHID(0);
+	Graphid		id2 = PG_GETARG_GRAPHID(1);
 
 	if (id1 < id2)
 		return -1;
@@ -1347,6 +1347,15 @@ graphid_hash(PG_FUNCTION_ARGS)
 	StaticAssertStmt(sizeof(id) == 8, "the size of graphid must be 8");
 
 	return hash_any((unsigned char *) &id, sizeof(id));
+}
+
+/* HASHPROC (1) */
+Datum
+vertex_hash(PG_FUNCTION_ARGS)
+{
+	Datum id = getVertexIdDatum(PG_GETARG_DATUM(0));
+
+	PG_RETURN_DATUM(DirectFunctionCall1(graphid_hash, id));
 }
 
 /*

--- a/src/include/catalog/pg_amop.h
+++ b/src/include/catalog/pg_amop.h
@@ -1187,6 +1187,12 @@ DATA(insert ( 7105 7002 7002  4 s 7092 3580 0 ));
 DATA(insert ( 7105 7002 7002  5 s 7090 3580 0 ));
 
 /*
+ * vertex_ops
+ */
+/* Hash */
+DATA(insert ( 7106 7012 7012  1 s 7136  405 0 ));
+
+/*
  * rowid_ops
  */
 /* BTree */

--- a/src/include/catalog/pg_amproc.h
+++ b/src/include/catalog/pg_amproc.h
@@ -556,6 +556,12 @@ DATA(insert ( 7105 7002 7002  3 3385 ));
 DATA(insert ( 7105 7002 7002  4 3386 ));
 
 /*
+ * graphid_ops
+ */
+/* Hash */
+DATA(insert ( 7106 7012 7012  1 7107 ));
+
+/*
  * rowid_ops
  */
 /* BTree */

--- a/src/include/catalog/pg_opclass.h
+++ b/src/include/catalog/pg_opclass.h
@@ -252,6 +252,8 @@ DATA(insert (  405 graphid_ops          PGNSP PGUID 7096 7002 t 0 ));
 DATA(insert ( 2742 graphid_ops          PGNSP PGUID 7098 7002 t 0 ));
 DATA(insert ( 3580 graphid_minmax_ops   PGNSP PGUID 7105 7002 t 0 ));
 
+DATA(insert (  405 vertex_ops           PGNSP PGUID 7106 7012 t 0 ));
+
 DATA(insert (  403 rowid_ops          	PGNSP PGUID 7167 7062 t 0 ));
 
 #endif							/* PG_OPCLASS_H */

--- a/src/include/catalog/pg_opfamily.h
+++ b/src/include/catalog/pg_opfamily.h
@@ -193,6 +193,8 @@ DATA(insert OID = 7096 (  405 graphid_ops           PGNSP PGUID ));
 DATA(insert OID = 7098 ( 2742 graphid_ops           PGNSP PGUID ));
 DATA(insert OID = 7105 ( 3580 graphid_minmax_ops    PGNSP PGUID ));
 
+DATA(insert OID = 7106 (  405 vertex_ops            PGNSP PGUID ));
+
 DATA(insert OID = 7167 (  403 rowid_ops             PGNSP PGUID ));
 
 #endif							/* PG_OPFAMILY_H */

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5561,6 +5561,9 @@ DATA(insert OID = 7102 ( gin_consistent_graphid		PGNSP PGUID 12 1 0 0 0 f f f f 
 DESCR("GIN graphid support");
 DATA(insert OID = 7103 ( gin_compare_partial_graphid PGNSP PGUID 12 1 0 0 0 f f f f t f i s 4 0 23 "7002 7002 21 2281" _null_ _null_ _null_ _null_ _null_ gin_compare_partial_graphid _null_ _null_ _null_ ));
 DESCR("GIN graphid support");
+/* Hash for vertex */
+DATA(insert OID = 7107 ( vertex_hash	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 23 "7012" _null_ _null_ _null_ _null_ _null_ vertex_hash _null_ _null_ _null_ ));
+DESCR("hash");
 /* describe labels */
 DATA(insert OID = 7110 ( ag_get_propindexdef		PGNSP PGUID 12 1 0 0 0 f f f f t f s s 1 0 25 "26" _null_ _null_ _null_ _null_ _null_ ag_get_propindexdef _null_ _null_ _null_ ));
 DESCR("describe property index");


### PR DESCRIPTION
This change adds the following entries to the catalog to make vertex
hashable.

* `vertex_hash` function (and C implementation of it)
* A `vertex_ops` operator family for hash
* A `vertex_ops` operator class for `vertex` type and `vertex_ops`
  operator family
* The existing `vertex = vertex` operator as an access method operator
  for `vertex_ops` operator family
* `vertex_hash` function as a support prodecure for `vertex_ops`
  operator family

Run the following SQL statements as a superuser to update the existing
catalog.

```
CREATE FUNCTION pg_catalog.vertex_hash(pg_catalog.vertex)
  RETURNS pg_catalog.int4
  LANGUAGE internal
  IMMUTABLE
  STRICT
  PARALLEL SAFE
  AS 'vertex_hash';

CREATE OPERATOR FAMILY pg_catalog.vertex_ops USING hash;

CREATE OPERATOR CLASS pg_catalog.vertex_ops
  DEFAULT FOR TYPE pg_catalog.vertex
  USING hash
  AS
    OPERATOR 1 pg_catalog.=,
    FUNCTION 1 pg_catalog.vertex_hash(pg_catalog.vertex);
```