### PR TITLE
fix: Make all Cypher log() calls use ln(), the natural logarithm

### DIFF
--- a/src/backend/parser/parse_cypher_expr.c
+++ b/src/backend/parser/parse_cypher_expr.c
@@ -862,6 +862,10 @@ transformFuncCall(ParseState *pstate, FuncCall *fn)
 
 		if (strcmp(funcname, "stdevp") == 0)
 			fn->funcname = list_make1(makeString("stddev_pop"));
+
+		/* translate log() into ln() for cypher queries */
+		if (strcmp(funcname, "log") == 0)
+			fn->funcname = list_make1(makeString("ln"));
 	}
 
 	args = preprocess_func_args(pstate, fn);

--- a/src/test/regress/expected/cypher_func.out
+++ b/src/test/regress/expected/cypher_func.out
@@ -209,3 +209,49 @@ drop cascades to vlabel a
 drop cascades to vlabel b
 drop cascades to vlabel c
 drop cascades to vlabel d
+-- Added test for AG249, use ln() for all log() calls
+-- Create initial graph
+CREATE GRAPH ag249_log_to_ln;
+SET graph_path = ag249_log;
+ERROR:  invalid value for parameter "graph_path": "ag249_log"
+DETAIL:  graph "ag249_log" does not exist.
+CREATE VLABEL numbers;
+CREATE (:numbers {string: '10', numeric: 10});
+-- These should fail as there is no rule to cast from string to numeric
+MATCH (u:numbers) RETURN log(u.string);
+ERROR:  "10" cannot be converted to numeric
+MATCH (u:numbers) RETURN ln(u.string);
+ERROR:  "10" cannot be converted to numeric
+MATCH (u:numbers) RETURN log10(u.string);
+ERROR:  log10(): number is expected but "10"
+-- Check that log() == ln() != log10
+MATCH (u:numbers) RETURN log(u.numeric), ln(u.numeric), log10(u.numeric);
+         ln         |         ln         |       log10        
+--------------------+--------------------+--------------------
+ 2.3025850929940457 | 2.3025850929940457 | 1.0000000000000000
+(1 row)
+
+-- Check with a string constant
+RETURN log('10'), ln('10'), log10('10');
+ERROR:  log10(): number is expected but "10"
+-- Check with a numeric constant;
+RETURN log(10), ln(10), log10(10);
+        ln        |        ln        |       log10        
+------------------+------------------+--------------------
+ 2.30258509299405 | 2.30258509299405 | 1.0000000000000000
+(1 row)
+
+-- Check hybrid query
+return log10(10), (select log(10));
+       log10        | log 
+--------------------+-----
+ 1.0000000000000000 | 1
+(1 row)
+
+-- cleanup
+DROP GRAPH ag249_log_to_ln CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to sequence ag249_log_to_ln.ag_label_seq
+drop cascades to vlabel ag_vertex
+drop cascades to elabel ag_edge
+drop cascades to vlabel numbers

--- a/src/test/regress/sql/cypher_func.sql
+++ b/src/test/regress/sql/cypher_func.sql
@@ -121,3 +121,30 @@ MATCH (n) RETURN n.name, label(n), labels(n);
 DROP GRAPH vertex_labels_complex2 CASCADE;
 DROP GRAPH vertex_labels_complex1 CASCADE;
 DROP GRAPH vertex_labels_simple CASCADE;
+
+-- Added test for AG249, use ln() for all log() calls
+-- Create initial graph
+CREATE GRAPH ag249_log_to_ln;
+SET graph_path = ag249_log;
+CREATE VLABEL numbers;
+CREATE (:numbers {string: '10', numeric: 10});
+
+-- These should fail as there is no rule to cast from string to numeric
+MATCH (u:numbers) RETURN log(u.string);
+MATCH (u:numbers) RETURN ln(u.string);
+MATCH (u:numbers) RETURN log10(u.string);
+
+-- Check that log() == ln() != log10
+MATCH (u:numbers) RETURN log(u.numeric), ln(u.numeric), log10(u.numeric);
+
+-- Check with a string constant
+RETURN log('10'), ln('10'), log10('10');
+
+-- Check with a numeric constant;
+RETURN log(10), ln(10), log10(10);
+
+-- Check hybrid query
+return log10(10), (select log(10));
+
+-- cleanup
+DROP GRAPH ag249_log_to_ln CASCADE;


### PR DESCRIPTION
Notation: log10() refers to log base 10, ln() refers to log base e,
the natural logarithm.

The issue -

* Postgres SQL uses log10() for the log() function.

* Cypher uses ln() for the log() function.

* Our current implementation has a mix of log10() and ln() for
  Cypher queries using the log() function - based on type.

A decision was made to make our implementation of Cypher mirror the
standard. So, all Cypher log() function calls are to use ln() under
the hood.

To do this the following was changed -

* `parse_cypher_expr.c` was modified to transform all Cypher log()
  function calls to ln(), the Postgres internal function for ln().

* `cypher_func.sql` had regression tests added for the above change.

* `cypher_func.out` had the correct regression test output added
  for the above tests.

Note: This is a fix for AG-249

-jrg