### PR TITLE
fix: Remove jsonb type casts from pg_cast (AG-245)

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2259,6 +2259,8 @@ _copyCypherTypeCast(const CypherTypeCast *from)
 
 	COPY_SCALAR_FIELD(type);
 	COPY_SCALAR_FIELD(cform);
+	COPY_SCALAR_FIELD(cctx);
+	COPY_SCALAR_FIELD(typcategory);
 	COPY_NODE_FIELD(arg);
 	COPY_LOCATION_FIELD(location);
 

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -822,6 +822,14 @@ _equalCypherTypeCast(const CypherTypeCast *a, const CypherTypeCast *b)
 {
 	COMPARE_SCALAR_FIELD(type);
 	COMPARE_COERCIONFORM_FIELD(cform);
+	/*
+	 * The following fields were purposely left out-
+	 *
+	 * cctx field is how the function came into existance. This is
+	 * unnecessary for comparisons.
+	 *
+	 * typcategory field is built from the type field - it's superfluous.
+	 */
 	COMPARE_NODE_FIELD(arg);
 	COMPARE_LOCATION_FIELD(location);
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1790,6 +1790,8 @@ _outCypherTypeCast(StringInfo str, const CypherTypeCast *node)
 
 	WRITE_OID_FIELD(type);
 	WRITE_ENUM_FIELD(cform, CoercionForm);
+	WRITE_ENUM_FIELD(cctx, CoercionContext);
+	WRITE_CHAR_FIELD(typcategory);
 	WRITE_NODE_FIELD(arg);
 	WRITE_LOCATION_FIELD(location);
 }

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2584,6 +2584,8 @@ _readCypherTypeCast(void)
 
 	READ_OID_FIELD(type);
 	READ_ENUM_FIELD(cform, CoercionForm);
+	READ_ENUM_FIELD(cctx, CoercionContext);
+	READ_CHAR_FIELD(typcategory);
 	READ_NODE_FIELD(arg);
 	READ_LOCATION_FIELD(location);
 

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -3580,10 +3580,12 @@ eval_const_expressions_mutator(Node *node,
 
 				newarg = eval_const_expressions_mutator((Node *) tc->arg,
 														context);
-
 				newtc = makeNode(CypherTypeCast);
 				newtc->type = tc->type;
+				/* add cctx and typcategory for runtime type casting */
+				newtc->cctx = tc->cctx;
 				newtc->cform = tc->cform;
+				newtc->typcategory = tc->typcategory;
 				newtc->arg = (Expr *) newarg;
 				newtc->location = tc->location;
 

--- a/src/backend/parser/parse_shortestpath.c
+++ b/src/backend/parser/parse_shortestpath.c
@@ -1363,9 +1363,8 @@ makeDijkstraFrom(ParseState *parentParseState, CypherPath *cpath)
 	{
 		Node	   *weight;
 
-		weight = coerce_to_target_type(pstate, target, wtype, FLOAT8OID, -1,
-									   COERCION_EXPLICIT, COERCE_EXPLICIT_CAST,
-									   -1);
+		weight = coerce_expr(pstate, target, wtype, FLOAT8OID, -1,
+							 COERCION_EXPLICIT, COERCE_EXPLICIT_CAST, -1);
 		if (weight == NULL)
 			ereport(ERROR,
 					(errcode(ERRCODE_DATATYPE_MISMATCH),

--- a/src/backend/utils/adt/cypher_ops.c
+++ b/src/backend/utils/adt/cypher_ops.c
@@ -22,7 +22,6 @@ static Jsonb *jnumber_op(PGFunction f, Jsonb *l, Jsonb *r);
 static Jsonb *numeric_to_jnumber(Numeric n);
 static void ereport_op(PGFunction f, Jsonb *l, Jsonb *r);
 static void ereport_op_str(const char *op, Jsonb *l, Jsonb *r);
-static Datum get_numeric_0_datum(void);
 static Datum jsonb_num(Jsonb *j, PGFunction f);
 
 Datum
@@ -285,64 +284,6 @@ ereport_op_str(const char *op, Jsonb *l, Jsonb *r)
 	ereport(ERROR,
 			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 			 errmsg(msgfmt, lstr, op, rstr)));
-}
-
-Datum
-jsonb_bool(PG_FUNCTION_ARGS)
-{
-	Jsonb	   *j = PG_GETARG_JSONB(0);
-
-	if (JB_ROOT_IS_SCALAR(j))
-	{
-		JsonbValue *jv;
-
-		jv = getIthJsonbValueFromContainer(&j->root, 0);
-		switch (jv->type)
-		{
-			case jbvNull:
-				PG_RETURN_NULL();
-			case jbvString:
-				PG_RETURN_BOOL(jv->val.string.len > 0);
-			case jbvNumeric:
-				{
-					Datum		b;
-
-					if (numeric_is_nan(jv->val.numeric))
-						PG_RETURN_BOOL(false);
-
-					b = DirectFunctionCall2(numeric_ne,
-											NumericGetDatum(jv->val.numeric),
-											get_numeric_0_datum());
-					PG_RETURN_DATUM(b);
-				}
-			case jbvBool:
-				PG_RETURN_BOOL(jv->val.boolean);
-			default:
-				elog(ERROR, "unknown jsonb scalar type");
-		}
-	}
-
-	Assert(JB_ROOT_IS_OBJECT(j) || JB_ROOT_IS_ARRAY(j));
-	PG_RETURN_BOOL(JB_ROOT_COUNT(j) > 0);
-}
-
-static Datum
-get_numeric_0_datum(void)
-{
-	static Datum n = 0;
-
-	if (n == 0)
-	{
-		MemoryContext oldMemoryContext;
-
-		oldMemoryContext = MemoryContextSwitchTo(TopMemoryContext);
-
-		n = DirectFunctionCall1(int8_numeric, Int64GetDatum(0));
-
-		MemoryContextSwitchTo(oldMemoryContext);
-	}
-
-	return n;
 }
 
 Datum

--- a/src/include/catalog/pg_cast.h
+++ b/src/include/catalog/pg_cast.h
@@ -396,17 +396,6 @@ DATA(insert ( 3802	114    0 a i ));
 DATA(insert ( 7012 3802 7019 i f ));
 DATA(insert ( 7022 3802 7029 i f ));
 
-/* coercions between jsonb and bool */
-DATA(insert ( 3802   16 7191 a f ));
-DATA(insert (   16 3802 7192 i f ));
-
-/* assignment coercion from jsonb to int8/int4 */
-DATA(insert ( 3802   20 7193 a f ));
-DATA(insert ( 3802   23 7194 a f ));
-/* explicit coercion from jsonb to numeric/float8 */
-DATA(insert ( 3802 1700 7195 e f ));
-DATA(insert ( 3802  701 7196 e f ));
-
 /* implicit coercion from numeric to graphid */
 DATA(insert ( 1700 7002 7245 i f ));
 

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5625,8 +5625,6 @@ DATA(insert OID = 7185 ( jsonb_pow		PGNSP PGUID 12 1 0 0 0 f f f f t f i s 2 0 3
 DATA(insert OID = 7187 ( jsonb_uplus	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 3802 "3802" _null_ _null_ _null_ _null_ _null_ jsonb_uplus _null_ _null_ _null_ ));
 DATA(insert OID = 7189 ( jsonb_uminus	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 3802 "3802" _null_ _null_ _null_ _null_ _null_ jsonb_uminus _null_ _null_ _null_ ));
 /* Cypher expressions - coercions between jsonb and bool */
-DATA(insert OID = 7191 ( bool		PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 16 "3802" _null_ _null_ _null_ _null_ _null_ jsonb_bool _null_ _null_ _null_ ));
-DESCR("convert jsonb to bool");
 DATA(insert OID = 7192 ( jsonb		PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 3802 "16" _null_ _null_ _null_ _null_ _null_ bool_jsonb _null_ _null_ _null_ ));
 DESCR("convert bool to jsonb");
 /* Cypher expressions - coercion from jsonb to int8/int4/numeric/float */

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -21,7 +21,6 @@
 #include "nodes/bitmapset.h"
 #include "nodes/pg_list.h"
 
-
 /* ----------------------------------------------------------------
  *						node definitions
  * ----------------------------------------------------------------
@@ -1504,12 +1503,14 @@ typedef struct OnConflictExpr
 /*
  * Cypher Query Language
  */
-
 typedef struct CypherTypeCast
 {
 	Expr		xpr;
 	Oid			type;
+	/* add coercion context and type category for runtime type casting */
+	CoercionContext cctx;
 	CoercionForm cform;
+	char		typcategory;
 	Expr	   *arg;
 	int			location;
 } CypherTypeCast;

--- a/src/include/utils/cypher_ops.h
+++ b/src/include/utils/cypher_ops.h
@@ -23,7 +23,6 @@ extern Datum jsonb_uplus(PG_FUNCTION_ARGS);
 extern Datum jsonb_uminus(PG_FUNCTION_ARGS);
 
 /* coercions between jsonb and bool */
-extern Datum jsonb_bool(PG_FUNCTION_ARGS);
 extern Datum bool_jsonb(PG_FUNCTION_ARGS);
 
 /* coercion from jsonb to int8/int4/numeric/float8 */

--- a/src/test/regress/expected/cypher_func.out
+++ b/src/test/regress/expected/cypher_func.out
@@ -212,16 +212,14 @@ drop cascades to vlabel d
 -- Added test for AG249, use ln() for all log() calls
 -- Create initial graph
 CREATE GRAPH ag249_log_to_ln;
-SET graph_path = ag249_log;
-ERROR:  invalid value for parameter "graph_path": "ag249_log"
-DETAIL:  graph "ag249_log" does not exist.
+SET graph_path = ag249_log_to_ln;
 CREATE VLABEL numbers;
 CREATE (:numbers {string: '10', numeric: 10});
 -- These should fail as there is no rule to cast from string to numeric
 MATCH (u:numbers) RETURN log(u.string);
-ERROR:  "10" cannot be converted to numeric
+ERROR:  cannot cast "10" (jsonb type string) to numeric
 MATCH (u:numbers) RETURN ln(u.string);
-ERROR:  "10" cannot be converted to numeric
+ERROR:  cannot cast "10" (jsonb type string) to numeric
 MATCH (u:numbers) RETURN log10(u.string);
 ERROR:  log10(): number is expected but "10"
 -- Check that log() == ln() != log10

--- a/src/test/regress/expected/cypher_plpgsql.out
+++ b/src/test/regress/expected/cypher_plpgsql.out
@@ -67,12 +67,11 @@ RETURN false;
 END IF;
 END;
 $$ LANGUAGE plpgsql;
+-- This test originally worked due to a side effect of having a cast from jsonb
+-- to boolean. That cast has been removed, so now this will fail as expected.
 SELECT udf_if();
- udf_if 
---------
- t
-(1 row)
-
+ERROR:  invalid input syntax for type boolean: ""knows""
+CONTEXT:  PL/pgSQL function udf_if() line 3 at IF
 CREATE OR REPLACE FUNCTION udf_if_exists() RETURNS boolean AS $$
 BEGIN
 IF EXISTS ( MATCH (a)-[b]->(c) WHERE a.name = 'Anders' AND c.name = 'Bossman' RETURN b ) THEN

--- a/src/test/regress/expected/cypher_substring.out
+++ b/src/test/regress/expected/cypher_substring.out
@@ -36,13 +36,9 @@ MATCH (u:string) RETURN substring(u.sval, 3, 1);
  ""
 (1 row)
 
--- Sanity check for cast to text
+-- Sanity check for cast to text -- this should fail now
 MATCH (u:string) RETURN substring(u.nval, 1, 1);
- substring 
------------
- "2"
-(1 row)
-
+ERROR:  cannot cast 123 (jsonb type numeric) to text
 -- Check Cypher substring(string, start) from graph
 MATCH (u:string) RETURN substring(u.sval, -1);
  substring 
@@ -74,13 +70,9 @@ MATCH (u:string) RETURN substring(u.sval, 3);
  ""
 (1 row)
 
--- Sanity check for cast to text
+-- Sanity check for cast to text -- this should fail now
 MATCH (u:string) RETURN substring(u.nval, 1);
- substring 
------------
- "23"
-(1 row)
-
+ERROR:  cannot cast 123 (jsonb type numeric) to text
 -- Check Cypher substring(string, start, length) from constant
 RETURN substring('123', -1, 1);
  substring 

--- a/src/test/regress/sql/cypher_func.sql
+++ b/src/test/regress/sql/cypher_func.sql
@@ -125,7 +125,7 @@ DROP GRAPH vertex_labels_simple CASCADE;
 -- Added test for AG249, use ln() for all log() calls
 -- Create initial graph
 CREATE GRAPH ag249_log_to_ln;
-SET graph_path = ag249_log;
+SET graph_path = ag249_log_to_ln;
 CREATE VLABEL numbers;
 CREATE (:numbers {string: '10', numeric: 10});
 

--- a/src/test/regress/sql/cypher_plpgsql.sql
+++ b/src/test/regress/sql/cypher_plpgsql.sql
@@ -69,6 +69,8 @@ END IF;
 END;
 $$ LANGUAGE plpgsql;
 
+-- This test originally worked due to a side effect of having a cast from jsonb
+-- to boolean. That cast has been removed, so now this will fail as expected.
 SELECT udf_if();
 
 CREATE OR REPLACE FUNCTION udf_if_exists() RETURNS boolean AS $$

--- a/src/test/regress/sql/cypher_substring.sql
+++ b/src/test/regress/sql/cypher_substring.sql
@@ -14,7 +14,7 @@ MATCH (u:string) RETURN substring(u.sval, 1, 1);
 MATCH (u:string) RETURN substring(u.sval, 2, 1);
 MATCH (u:string) RETURN substring(u.sval, 3, 1);
 
--- Sanity check for cast to text
+-- Sanity check for cast to text -- this should fail now
 MATCH (u:string) RETURN substring(u.nval, 1, 1);
 
 -- Check Cypher substring(string, start) from graph
@@ -24,7 +24,7 @@ MATCH (u:string) RETURN substring(u.sval, 1);
 MATCH (u:string) RETURN substring(u.sval, 2);
 MATCH (u:string) RETURN substring(u.sval, 3);
 
--- Sanity check for cast to text
+-- Sanity check for cast to text -- this should fail now
 MATCH (u:string) RETURN substring(u.nval, 1);
 
 -- Check Cypher substring(string, start, length) from constant


### PR DESCRIPTION
This change removes jsonb type casts from pg_cast and adjusts the code
accordingly to provide those casts programmatically. See AG-245 for
more details.

In order to facilitate these changes, CoercionContext and TYPCATEGORY
fields are added to the CypherTypeCast structure. These additions
enable more granularity in the `ExecEvalCypherTypeCast` runtime
coercions.  This added granularity is needed to make the correct
casts at runtime.

The casts removed from pg_cast are as follows -

* Casts between JSONBOID and BOOLOID

* Casts from JSONBOID to INT4OID, INT8OID, FLOAT8OID, & NUMERICOID

These casts are programmatically added to -

* `coerce_expr` is rewritten to prioritize our JSONBOID casts over
  those of postgres, to create the CypherTypeCast for our casts, and
  to populate the CoercionContext and TYPCATEGORY fields.

* `eval_const_expressions_mutator` is adjusted to include the
  additions listed above in building new CypherTypeCast nodes.

* `ExecEvalCypherTypeCast` is adjusted to execute the new casts.

The `_copyCypherTypeCast`, `_equalCypherTypeCast`,
`_outCypherTypeCast`, and `_readCypherTypeCast` functions are modified
to support the added fields in CypherTypeCast.

The `makeDijkstraFrom` function is modified to use the new
`coerce_expr` function. Without this change it will throw an error due
to the missing type casts that are now incorporated in `coerce_expr`.

The following functions now use the new `coerce_cypher_arg_to_boolean`
function, which in turn uses the newer `coerce_expr` function -

* `transformCaseExpr` for CASE/WHEN clauses.

* `transformBoolExpr` for NOT/AND/OR expressions.

* `transformCypherWhere` for WHERE clauses.

The `jsonb_bool` function is now integrated in `ExecEvalCypherTypeCast`
and consequently, is removed.

The following regression tests are corrected to note the expected
failures. The original successes of these tests were due to type casts
that created side effects. So, now they fail - which is expected.

* `cypher_plpgsql.sql` and `cypher_plpgsql.out`.

* `cypher_substring.sql` and `cypher_substring.out`.

-jrg