### PR TITLE
fix: Improper type casting of ANY*OID (AG-255)

### DIFF
--- a/src/backend/parser/parse_cypher_expr.c
+++ b/src/backend/parser/parse_cypher_expr.c
@@ -1925,16 +1925,18 @@ coerce_expr(ParseState *pstate, Node *expr, Oid ityp, Oid otyp, int32 otypmod,
 	 * VERTEXOID  -> JSONBOID
 	 * EDGEOID    -> JSONBOID
 	 * UNKNOWNOID -> JSONBOID
+	 * JSONBOID   -> ANY*OID  ANYOID & (IsPolymorphicType)
 	 * We need to let postgres process these.
 	 */
 	if (ityp != JSONOID && otyp != JSONOID &&
 		ityp != VERTEXOID && ityp != EDGEOID &&
-		ityp != UNKNOWNOID)
+		ityp != UNKNOWNOID &&
+		otyp != ANYOID &&
+		!IsPolymorphicType(otyp))
 	{
 		if (ityp == JSONBOID)
 		{
 			if (OidIsValid(get_element_type(otyp)) ||
-				otyp == ANYARRAYOID ||
 				otyp == RECORDARRAYOID ||
 				type_is_rowtype(otyp))
 			{


### PR DESCRIPTION
This fix is to correct issue AG-255 "The Collect function...".

The issue is caused by our new `coerce_expr` function processing
ANY*OID (ex: ANYARRAYOID, ANYENUMOID, etc) output types and wrapping
them in a CypherTypeCast node.

Prior to AG-245, the `coerce_to_target_type` function processed the
ANY*OID output types and just returned the node.

This fix adds in checks for ANY*OID output types so that we avoid
processing them and leave them for `coerce_to_target_type`.

-jrg