### PR TITLE
fix: Shorestpath crashed on FieldSelect exprs (AG-252)

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2179,6 +2179,10 @@ typedef struct Hash2SideState
 	double          totalPaths;
 	long            hops;
 	Size            spacePeak;
+	bool			isFieldSelect;	/* Track FieldSelect exprs */
+	Param		   *correctedParam;	/* Needed to correct FieldSelect exprs */
+	HeapTuple		vertexRow;		/* For reusing the vertexRow */
+	TupleDesc		tupleDesc;		/* Tuple descriptor for above vertexRow */
 } Hash2SideState;
 
 typedef struct ShortestpathState


### PR DESCRIPTION
This fix is to correct issue AG-252 which is due to FieldSelect
expressions that are unexpected.

The original shortest path algorithm appears to have not anticipated the
cases where the source/target expressions might be something other than a
Param expression. To fix this issue, logic needed to be added to allow
FieldSelect expressions in source/target nodes.

The following is done to correct the issue -

The Hash2SideState structure had the following fields added to support
the fix.

* bool       isFieldSelect;  To flag a FieldSelect node.
* Param	    *correctedParam; To hold the corrected Param node.
* HeapTuple  vertexRow;      To hold the vertexRow for reuse;
* TupleDesc  tupleDesc;      To hold a tuple descriptor for reuse.

The support function `replace_vertexRow_graphid` is added to allow reusing
a vertexRow by replacing its contained graphid value.

The `ExecReScanShortestpath` function is fixed to use the correct Param
node.

The `ExecShortestpathRescanOuterNode` function is fixed to use the
correct Param node and logic is added to pass a reused vertexRow with
the correct graphid when the expression node is a FieldSelect.

The `ExecInitShortestpath` function is modified to initialize the new
fields in the Hash2SideState structure. Additionally, it creates a
tuple descriptor and vertexRow as needed. These are freed in the end
function.

The `ExecEndShortestpath` function is modified to clean up both the
vertexRow and tuple descriptor allocated in the init function.

Note: It appears like the Dijkstra path algorithm uses similar logic
and may have similar issues.

-jrg