### PR TITLE
fix: ExecDijkstra crashes on FieldSelect exprs (AG-260)

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2239,6 +2239,8 @@ typedef struct DijkstraState
 	Graphid 		target_id;
 	bool			is_executed;
 	TupleTableSlot *selfTupleSlot;
+	HeapTuple		vertexRow;		/* pointer to hold reusable vertex row */
+	TupleDesc		tupleDesc;		/* pointer to vertex row's tuple descr */
 } DijkstraState;
 
 #endif							/* EXECNODES_H */


### PR DESCRIPTION
This fix is to correct issue AG-260 which is due to FieldSelect
expressions that are unexpected in ExecDijkstra.

Please see commit d77f5bfc68e44c4136fa91e8db368cf8c40fdd09 for an
explaination of the issue. The fix is also similar, with the exception
of the need to only deal with the source node.

-jrg