### PR TITLE
fix: LIMIT clause causes VLEs [*] to crash (AG-254)

### DIFF
--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -3436,6 +3436,8 @@ DEALLOCATE t;
 CREATE GRAPH asterisk;
 CREATE VLABEL vertex;
 CREATE ELABEL edge;
+CREATE VLABEL city; -- additional VLABELs cause crashes (used or not)
+CREATE ELABEL road; -- additional ELABELs cause crashes (used or not)
 CREATE (a0:vertex {name: 'A'})
 CREATE (b0:vertex {name: 'B'})
 CREATE (q0:vertex {name: 'Q'})
@@ -3519,12 +3521,14 @@ MATCH p=((u)-[*..3]->(v)) RETURN p LIMIT 5; -- crash
 (5 rows)
 
 DROP GRAPH asterisk CASCADE;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to sequence asterisk.ag_label_seq
 drop cascades to vlabel ag_vertex
 drop cascades to elabel ag_edge
 drop cascades to vlabel vertex
 drop cascades to elabel edge
+drop cascades to vlabel city
+drop cascades to elabel road
 -- cleanup
 DROP GRAPH srf CASCADE;
 NOTICE:  drop cascades to 5 other objects

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -3432,6 +3432,99 @@ EXECUTE t(ARRAY['{"a": [[1, 2], [3, 4]]}'::jsonb,
 (8 rows)
 
 DEALLOCATE t;
+-- LIMIT clause causes VLE relations to crash, issue AG-254
+CREATE GRAPH asterisk;
+CREATE VLABEL vertex;
+CREATE ELABEL edge;
+CREATE (a0:vertex {name: 'A'})
+CREATE (b0:vertex {name: 'B'})
+CREATE (q0:vertex {name: 'Q'})
+CREATE (x0:vertex {name: 'X'})
+MERGE (a0)-[:edge]->(b0)
+MERGE (q0)-[:edge]->(a0)
+MERGE (b0)-[:edge]->(q0)
+MERGE (a0)-[:edge]->(x0)
+MERGE (x0)-[:edge]->(b0);
+-- 4 row set
+MATCH p=((u:vertex {name: 'A'})-[*]->(v:vertex {name: 'B'}))
+RETURN p LIMIT 4; --crash
+                                                                                                                                p                                                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"}]
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"},edge[4.3][3.2,3.3]{},vertex[3.3]{"name": "Q"},edge[4.2][3.3,3.1]{},vertex[3.1]{"name": "A"},edge[4.4][3.1,3.4]{},vertex[3.4]{"name": "X"},edge[4.5][3.4,3.2]{},vertex[3.2]{"name": "B"}]
+ [vertex[3.1]{"name": "A"},edge[4.4][3.1,3.4]{},vertex[3.4]{"name": "X"},edge[4.5][3.4,3.2]{},vertex[3.2]{"name": "B"}]
+ [vertex[3.1]{"name": "A"},edge[4.4][3.1,3.4]{},vertex[3.4]{"name": "X"},edge[4.5][3.4,3.2]{},vertex[3.2]{"name": "B"},edge[4.3][3.2,3.3]{},vertex[3.3]{"name": "Q"},edge[4.2][3.3,3.1]{},vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"}]
+(4 rows)
+
+-- 22 row set
+MATCH p=((u)-[*0..3]->(v)) RETURN p LIMIT 0; --no crash (nc)
+ p 
+---
+(0 rows)
+
+MATCH p=((u)-[*0..3]->(v)) RETURN p LIMIT 1; --nc
+             p              
+----------------------------
+ [vertex[3.1]{"name": "A"}]
+(1 row)
+
+MATCH p=((u)-[*0..3]->(v)) RETURN p LIMIT 4; --nc/memory corrupted (mem)
+                                                                                  p                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [vertex[3.1]{"name": "A"}]
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"}]
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"},edge[4.3][3.2,3.3]{},vertex[3.3]{"name": "Q"}]
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"},edge[4.3][3.2,3.3]{},vertex[3.3]{"name": "Q"},edge[4.2][3.3,3.1]{},vertex[3.1]{"name": "A"}]
+(4 rows)
+
+MATCH p=((u)-[*0..3]->(v)) RETURN p LIMIT 5; --crash
+                                                                                  p                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [vertex[3.1]{"name": "A"}]
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"}]
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"},edge[4.3][3.2,3.3]{},vertex[3.3]{"name": "Q"}]
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"},edge[4.3][3.2,3.3]{},vertex[3.3]{"name": "Q"},edge[4.2][3.3,3.1]{},vertex[3.1]{"name": "A"}]
+ [vertex[3.1]{"name": "A"},edge[4.4][3.1,3.4]{},vertex[3.4]{"name": "X"}]
+(5 rows)
+
+-- 18 row set
+MATCH p=((u)-[*..3]->(v)) RETURN p LIMIT 0; -- nc
+ p 
+---
+(0 rows)
+
+MATCH p=((u)-[*..3]->(v)) RETURN p LIMIT 1; -- nc
+                                    p                                     
+--------------------------------------------------------------------------
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"}]
+(1 row)
+
+MATCH p=((u)-[*..3]->(v)) RETURN p LIMIT 4; -- nc/mem
+                                                                                  p                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"}]
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"},edge[4.3][3.2,3.3]{},vertex[3.3]{"name": "Q"}]
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"},edge[4.3][3.2,3.3]{},vertex[3.3]{"name": "Q"},edge[4.2][3.3,3.1]{},vertex[3.1]{"name": "A"}]
+ [vertex[3.1]{"name": "A"},edge[4.4][3.1,3.4]{},vertex[3.4]{"name": "X"}]
+(4 rows)
+
+MATCH p=((u)-[*..3]->(v)) RETURN p LIMIT 5; -- crash
+                                                                                  p                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"}]
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"},edge[4.3][3.2,3.3]{},vertex[3.3]{"name": "Q"}]
+ [vertex[3.1]{"name": "A"},edge[4.1][3.1,3.2]{},vertex[3.2]{"name": "B"},edge[4.3][3.2,3.3]{},vertex[3.3]{"name": "Q"},edge[4.2][3.3,3.1]{},vertex[3.1]{"name": "A"}]
+ [vertex[3.1]{"name": "A"},edge[4.4][3.1,3.4]{},vertex[3.4]{"name": "X"}]
+ [vertex[3.1]{"name": "A"},edge[4.4][3.1,3.4]{},vertex[3.4]{"name": "X"},edge[4.5][3.4,3.2]{},vertex[3.2]{"name": "B"}]
+(5 rows)
+
+DROP GRAPH asterisk CASCADE;
+NOTICE:  drop cascades to 5 other objects
+DETAIL:  drop cascades to sequence asterisk.ag_label_seq
+drop cascades to vlabel ag_vertex
+drop cascades to elabel ag_edge
+drop cascades to vlabel vertex
+drop cascades to elabel edge
 -- cleanup
 DROP GRAPH srf CASCADE;
 NOTICE:  drop cascades to 5 other objects

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -1357,6 +1357,9 @@ CREATE GRAPH asterisk;
 CREATE VLABEL vertex;
 CREATE ELABEL edge;
 
+CREATE VLABEL city; -- additional VLABELs cause crashes (used or not)
+CREATE ELABEL road; -- additional ELABELs cause crashes (used or not)
+
 CREATE (a0:vertex {name: 'A'})
 CREATE (b0:vertex {name: 'B'})
 CREATE (q0:vertex {name: 'Q'})

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -1350,6 +1350,41 @@ EXECUTE t(ARRAY['{"a": [[1, 2], [3, 4]]}'::jsonb,
                 '{"a": [[5, 6], [7, 8]]}'::jsonb]);
 DEALLOCATE t;
 
+-- LIMIT clause causes VLE relations to crash, issue AG-254
+
+CREATE GRAPH asterisk;
+
+CREATE VLABEL vertex;
+CREATE ELABEL edge;
+
+CREATE (a0:vertex {name: 'A'})
+CREATE (b0:vertex {name: 'B'})
+CREATE (q0:vertex {name: 'Q'})
+CREATE (x0:vertex {name: 'X'})
+MERGE (a0)-[:edge]->(b0)
+MERGE (q0)-[:edge]->(a0)
+MERGE (b0)-[:edge]->(q0)
+MERGE (a0)-[:edge]->(x0)
+MERGE (x0)-[:edge]->(b0);
+
+-- 4 row set
+MATCH p=((u:vertex {name: 'A'})-[*]->(v:vertex {name: 'B'}))
+RETURN p LIMIT 4; --crash
+
+-- 22 row set
+MATCH p=((u)-[*0..3]->(v)) RETURN p LIMIT 0; --no crash (nc)
+MATCH p=((u)-[*0..3]->(v)) RETURN p LIMIT 1; --nc
+MATCH p=((u)-[*0..3]->(v)) RETURN p LIMIT 4; --nc/memory corrupted (mem)
+MATCH p=((u)-[*0..3]->(v)) RETURN p LIMIT 5; --crash
+
+-- 18 row set
+MATCH p=((u)-[*..3]->(v)) RETURN p LIMIT 0; -- nc
+MATCH p=((u)-[*..3]->(v)) RETURN p LIMIT 1; -- nc
+MATCH p=((u)-[*..3]->(v)) RETURN p LIMIT 4; -- nc/mem
+MATCH p=((u)-[*..3]->(v)) RETURN p LIMIT 5; -- crash
+
+DROP GRAPH asterisk CASCADE;
+
 -- cleanup
 
 DROP GRAPH srf CASCADE;


### PR DESCRIPTION
This fix is to correct issue AG-254 which is due to how Postgres
implements the LIMIT clause - basically, terminating a query in
progress once it receives the requested number of rows from it.

The `ExecEndNestLoopVLE` function, which deals with cleanup for the VLE
nested loop, was not cleaning up its internal context stack. This
caused, in some cases, the index routines to improperly free the
contexts, sometimes attempting to free them twice.

The fix is to properly unwind the context stack. The following was done
to correct the issue -

* `ExecEndNestLoopVLE` was modified to clean up the context
  stack, if necessary, by calculating and checking its depth.

Additionally, regression tests were modified to include tests for this
fix -

* `regress/sql/cypher_dml.sql` - tests added.

* `regress/expected/cypher_dml.out` - includes new output.

Note: This fix compiles and passes all install checks.

-jrg