### PR TITLE
test: (ShortestPath) Fix regression for shortestpath

### DIFF
--- a/src/test/regress/expected/cypher_shortestpath.out
+++ b/src/test/regress/expected/cypher_shortestpath.out
@@ -55,41 +55,92 @@ RETURN ids(nodes(shortestpath((p)<-[:knows]-(f)))) AS ids;
 (6 rows)
 
 MATCH (p:person), (f:person) WHERE p.id = 3
-RETURN ids(nodes(shortestpath((p)-[:knows*]-(f)))) AS ids;
+RETURN ids(nodes(shortestpath((p)-[:knows*]->(f)))) AS ids;
     ids    
 -----------
- {3,2,1}
- {3,2}
- {3,4,3}
+ {}
+ {}
+ {}
  {3,4}
  {3,4,5}
  {3,4,5,6}
 (6 rows)
 
-MATCH (p:person), (f:person), x=shortestpath((p)-[:knows*]-(f))
+MATCH (p:person), (f:person) WHERE p.id = 3
+RETURN ids(nodes(shortestpath((p)<-[:knows*]-(f)))) AS ids;
+   ids   
+---------
+ {3,2,1}
+ {3,2}
+ {}
+ {}
+ {}
+ {}
+(6 rows)
+
+MATCH (p:person), (f:person) WHERE p.id = 3
+RETURN p.id as pid, length(ids(nodes(shortestpath((p)-[:knows*]-(f))))), f.id as fid
+ORDER BY pid, fid;
+ pid | length | fid 
+-----+--------+-----
+ 3   | 3      | 1
+ 3   | 2      | 2
+ 3   | 3      | 3
+ 3   | 2      | 4
+ 3   | 3      | 5
+ 3   | 4      | 6
+(6 rows)
+
+MATCH (p:person), (f:person), x=shortestpath((p)-[:knows*]->(f))
 WHERE p.id = 3
 RETURN ids(nodes(x)) AS ids;
     ids    
 -----------
- {3,2,1}
- {3,2}
- {3,4,3}
  {3,4}
  {3,4,5}
  {3,4,5,6}
-(6 rows)
+(3 rows)
+
+MATCH x=shortestpath((p:person)-[:knows*]->(f:person))
+WHERE p.id = 3
+RETURN ids(nodes(x)) AS ids;
+    ids    
+-----------
+ {3,4}
+ {3,4,5}
+ {3,4,5,6}
+(3 rows)
+
+MATCH (p:person), (f:person), x=shortestpath((p)<-[:knows*]-(f))
+WHERE p.id = 3
+RETURN ids(nodes(x)) AS ids;
+   ids   
+---------
+ {3,2,1}
+ {3,2}
+(2 rows)
+
+MATCH x=shortestpath((p:person)<-[:knows*]-(f:person))
+WHERE p.id = 3
+RETURN ids(nodes(x)) AS ids;
+   ids   
+---------
+ {3,2,1}
+ {3,2}
+(2 rows)
 
 MATCH x=shortestpath((p:person)-[:knows*]-(f:person))
 WHERE p.id = 3
-RETURN ids(nodes(x)) AS ids;
-    ids    
------------
- {3,2,1}
- {3,2}
- {3,4,3}
- {3,4}
- {3,4,5}
- {3,4,5,6}
+RETURN p.id as pid, f.id as fid, length(ids(nodes(x)))
+ORDER BY pid, fid;
+ pid | fid | length 
+-----+-----+--------
+ 3   | 1   | 3
+ 3   | 2   | 2
+ 3   | 3   | 3
+ 3   | 4   | 2
+ 3   | 5   | 3
+ 3   | 6   | 4
 (6 rows)
 
 MATCH (p:person), (f:person) WHERE p.id = 3

--- a/src/test/regress/sql/cypher_shortestpath.sql
+++ b/src/test/regress/sql/cypher_shortestpath.sql
@@ -41,15 +41,35 @@ MATCH (p:person), (f:person) WHERE p.id = 3
 RETURN ids(nodes(shortestpath((p)<-[:knows]-(f)))) AS ids;
 
 MATCH (p:person), (f:person) WHERE p.id = 3
-RETURN ids(nodes(shortestpath((p)-[:knows*]-(f)))) AS ids;
+RETURN ids(nodes(shortestpath((p)-[:knows*]->(f)))) AS ids;
 
-MATCH (p:person), (f:person), x=shortestpath((p)-[:knows*]-(f))
+MATCH (p:person), (f:person) WHERE p.id = 3
+RETURN ids(nodes(shortestpath((p)<-[:knows*]-(f)))) AS ids;
+
+MATCH (p:person), (f:person) WHERE p.id = 3
+RETURN p.id as pid, length(ids(nodes(shortestpath((p)-[:knows*]-(f))))), f.id as fid
+ORDER BY pid, fid;
+
+MATCH (p:person), (f:person), x=shortestpath((p)-[:knows*]->(f))
+WHERE p.id = 3
+RETURN ids(nodes(x)) AS ids;
+
+MATCH x=shortestpath((p:person)-[:knows*]->(f:person))
+WHERE p.id = 3
+RETURN ids(nodes(x)) AS ids;
+
+MATCH (p:person), (f:person), x=shortestpath((p)<-[:knows*]-(f))
+WHERE p.id = 3
+RETURN ids(nodes(x)) AS ids;
+
+MATCH x=shortestpath((p:person)<-[:knows*]-(f:person))
 WHERE p.id = 3
 RETURN ids(nodes(x)) AS ids;
 
 MATCH x=shortestpath((p:person)-[:knows*]-(f:person))
 WHERE p.id = 3
-RETURN ids(nodes(x)) AS ids;
+RETURN p.id as pid, f.id as fid, length(ids(nodes(x)))
+ORDER BY pid, fid;
 
 MATCH (p:person), (f:person) WHERE p.id = 3
 RETURN ids(nodes(shortestpath((p)-[:knows*0..1]-(f)))) AS ids;


### PR DESCRIPTION
previously `shortestpath` run without Parallel scan, but it now work with Parallel and the two results are returned differently depending on the situation.

and, another fix is free minimal tuples if needed.