### PR TITLE
fix: Corrects CypherTypecast in expression_tree_walker().

### DIFF
--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -2327,7 +2327,7 @@ expression_tree_walker(Node *node,
 			{
 				CypherTypeCast *tc = (CypherTypeCast *) node;
 
-				if (expression_tree_walker((Node *) tc->arg, walker, context))
+				if (walker((Node *) tc->arg, context))
 					return true;
 			}
 			break;

--- a/src/test/regress/expected/cypher_dml2.out
+++ b/src/test/regress/expected/cypher_dml2.out
@@ -1,0 +1,27 @@
+CREATE GRAPH cypher_dml2;
+CREATE VLABEL v1;
+EXPLAIN ( analyze false, verbose true, costs false, buffers false, timing false )
+MATCH (p:v1)
+return max(collect(p.name)) as col;
+ERROR:  aggregate function calls cannot be nested
+LINE 3: return max(collect(p.name)) as col;
+                   ^
+MATCH (p:v1)
+return max(collect(p.name)) as col;
+ERROR:  aggregate function calls cannot be nested
+LINE 2: return max(collect(p.name)) as col;
+                   ^
+MATCH (p:v1)
+with collect(p.name) as col
+RETURN max(col);
+ max 
+-----
+ 
+(1 row)
+
+DROP GRAPH cypher_dml2 CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to sequence cypher_dml2.ag_label_seq
+drop cascades to vlabel ag_vertex
+drop cascades to elabel ag_edge
+drop cascades to vlabel v1

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -127,7 +127,7 @@ test: fast_default
 test: stats
 
 # run cypher dml test
-test: cypher_dml cypher_shortestpath cypher_eager graphid
+test: cypher_dml cypher_dml2 cypher_shortestpath cypher_eager graphid
 
 # run graphmeta
 test: graphmeta

--- a/src/test/regress/sql/cypher_dml2.sql
+++ b/src/test/regress/sql/cypher_dml2.sql
@@ -1,0 +1,16 @@
+CREATE GRAPH cypher_dml2;
+
+CREATE VLABEL v1;
+
+EXPLAIN ( analyze false, verbose true, costs false, buffers false, timing false )
+MATCH (p:v1)
+return max(collect(p.name)) as col;
+
+MATCH (p:v1)
+return max(collect(p.name)) as col;
+
+MATCH (p:v1)
+with collect(p.name) as col
+RETURN max(col);
+
+DROP GRAPH cypher_dml2 CASCADE;


### PR DESCRIPTION
The argument of CypherTypeCast must be passed to "walker". but,
"expression_tree_walker" is called again and the "walker" cannot perform the
required tasks.

So, changed to call walker. If required, "expression_tree_walker" is called
back from "walker".

In addition, this corrects errors caused by Cypher not detecting the nested
aggregate function.