### PR TITLE
Implement Graph binary-upgrade

### DIFF
--- a/src/backend/catalog/ag_label.c
+++ b/src/backend/catalog/ag_label.c
@@ -24,24 +24,42 @@
 #include "utils/rel.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
+#include "miscadmin.h"
 
 static void InsertAgLabelTuple(Relation ag_label_desc, Oid laboid,
-							   RangeVar *label, Oid relid, char labkind);
+							   RangeVar *label, Oid relid, char labkind,
+							   bool is_fixed_id, int32 fixed_id);
 static uint16 GetNewLabelId(char *graphname, Oid graphid);
+
+/* Potentially set by pg_upgrade_support functions */
+Oid binary_upgrade_next_ag_label_oid = InvalidOid;
 
 Oid
 label_create_with_catalog(RangeVar *label, Oid relid, char labkind,
-						  Oid labtablespace)
+						  Oid labtablespace, bool is_fixed_id, int32 fixed_id)
 {
 	Relation	ag_label_desc;
 	Oid			laboid;
 
 	ag_label_desc = heap_open(LabelRelationId, RowExclusiveLock);
 
-	laboid = GetNewRelFileNode(labtablespace, ag_label_desc,
+	if (IsBinaryUpgrade)
+	{
+		if (!OidIsValid(binary_upgrade_next_ag_label_oid))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							errmsg("ag_label OID value not set when in binary upgrade mode")));
+		laboid = binary_upgrade_next_ag_label_oid;
+		binary_upgrade_next_ag_label_oid = InvalidOid;
+	}
+	else
+	{
+		laboid = GetNewRelFileNode(labtablespace, ag_label_desc,
 							   label->relpersistence);
+	}
 
-	InsertAgLabelTuple(ag_label_desc, laboid, label, relid, labkind);
+	InsertAgLabelTuple(ag_label_desc, laboid, label, relid, labkind,
+					   is_fixed_id, fixed_id);
 
 	heap_close(ag_label_desc, RowExclusiveLock);
 
@@ -79,7 +97,7 @@ label_drop_with_catalog(Oid laboid)
  */
 static void
 InsertAgLabelTuple(Relation ag_label_desc, Oid laboid, RangeVar *label,
-				   Oid relid, char labkind)
+				   Oid relid, char labkind, bool is_fixed_id, int32 fixed_id)
 {
 	Oid			graphid = get_graphname_oid(label->schemaname);
 	char		labname[NAMEDATALEN]={'\0'};
@@ -90,7 +108,12 @@ InsertAgLabelTuple(Relation ag_label_desc, Oid laboid, RangeVar *label,
 
 	AssertArg(labkind == LABEL_KIND_VERTEX || labkind == LABEL_KIND_EDGE);
 
-	labid = (int32) GetNewLabelId(label->schemaname, graphid);
+	if (is_fixed_id)
+	{
+		labid = fixed_id;
+	}
+	else
+		labid = (int32) GetNewLabelId(label->schemaname, graphid);
 	strcpy(labname, label->relname);
 
 	values[Anum_ag_label_oid - 1] = ObjectIdGetDatum(laboid);

--- a/src/backend/commands/graphcmds.c
+++ b/src/backend/commands/graphcmds.c
@@ -44,50 +44,74 @@
 #include "catalog/pg_inherits.h"
 
 static ObjectAddress DefineLabel(CreateStmt *stmt, char labkind,
-								 const char *queryString);
+								 const char *queryString, bool is_fixed_id,
+								 int32 fixed_id);
 static void GetSuperOids(List *supers, char labkind, List **supOids);
 static void AgInheritanceDependancy(Oid laboid, List *supers);
 static void SetMaxStatisticsTarget(Oid laboid);
 
 static bool IsLabel(const char *label_name, Oid namespaceId);
+static void SimpleProcessUtility(Node *node, const char *queryString,
+								 int stmt_location, int stmt_len);
 
 /* See ProcessUtilitySlow() case T_CreateSchemaStmt */
 void
 CreateGraphCommand(CreateGraphStmt *stmt, const char *queryString,
 				   int stmt_location, int stmt_len)
 {
-	Oid			graphid;
-	List	   *parsetree_list;
-	ListCell   *parsetree_item;
+	CreateSeqStmt *createSeqStmt;
+	CreateLabelStmt *createVLabelStmt, *createELabelStmt;
 
-	graphid = GraphCreate(stmt, queryString, stmt_location, stmt_len);
-	if (!OidIsValid(graphid))
-		return;
-
-	CommandCounterIncrement();
-
-	parsetree_list = transformCreateGraphStmt(stmt);
-	foreach(parsetree_item, parsetree_list)
+	if (stmt->kind & CGSK_SCHEMA)
 	{
-		Node	   *stmt = lfirst(parsetree_item);
-		PlannedStmt *wrapper;
-
-		wrapper = makeNode(PlannedStmt);
-		wrapper->commandType = CMD_UTILITY;
-		wrapper->canSetTag = false;
-		wrapper->utilityStmt = stmt;
-		wrapper->stmt_location = stmt_location;
-		wrapper->stmt_len = stmt_len;
-
-		ProcessUtility(wrapper, queryString, PROCESS_UTILITY_SUBCOMMAND,
-					   NULL, NULL, None_Receiver, NULL);
-
+		Oid graphid;
+		graphid = GraphCreate(stmt, queryString, stmt_location, stmt_len);
+		if (!OidIsValid(graphid))
+		{
+			/* If it already exists, it does not return the correct Oid. */
+			return;
+		}
 		CommandCounterIncrement();
 	}
 
-	if (graph_path == NULL || strcmp(graph_path, "") == 0)
+	if (stmt->kind & CGSK_SEQUENCE)
+	{
+		/* Create ag_label_seq */
+		createSeqStmt = makeDefaultCreateAGLabelSeqStmt(stmt->graphname,
+														stmt_location);
+		SimpleProcessUtility((Node *) createSeqStmt, queryString, stmt_location,
+							 stmt_len);
+		CommandCounterIncrement();
+	}
+
+	if (stmt->kind & CGSK_VLABEL)
+	{
+		/* Create ag_vertex table */
+		createVLabelStmt = makeDefaultCreateAGLabelStmt(stmt->graphname,
+														LABEL_VERTEX, stmt_location);
+		createVLabelStmt->only_base = (stmt->kind == CGSK_VLABEL);
+		SimpleProcessUtility((Node *) createVLabelStmt, queryString, stmt_location,
+							 stmt_len);
+		CommandCounterIncrement();
+	}
+
+	if (stmt->kind & CGSK_ELABEL)
+	{
+		/* Create ag_ege table */
+		createELabelStmt = makeDefaultCreateAGLabelStmt(stmt->graphname,
+														LABEL_EDGE, stmt_location);
+		createVLabelStmt->only_base = (stmt->kind == CGSK_ELABEL);
+		SimpleProcessUtility((Node *) createELabelStmt, queryString, stmt_location,
+							 stmt_len);
+		CommandCounterIncrement();
+	}
+
+	if (stmt->kind == CGSK_ALL &&
+		(graph_path == NULL || strcmp(graph_path, "") == 0))
+	{
 		SetConfigOption("graph_path", stmt->graphname,
 						PGC_USERSET, PGC_S_SESSION);
+	}
 }
 
 void
@@ -184,7 +208,8 @@ CreateLabelCommand(CreateLabelStmt *labelStmt, const char *queryString,
 
 		if (IsA(stmt, CreateStmt))
 		{
-			DefineLabel((CreateStmt *) stmt, labkind, queryString);
+			DefineLabel((CreateStmt *) stmt, labkind, queryString,
+						labelStmt->only_base, labelStmt->fixed_id);
 		}
 		else
 		{
@@ -212,7 +237,8 @@ CreateLabelCommand(CreateLabelStmt *labelStmt, const char *queryString,
 
 /* creates a new graph label */
 static ObjectAddress
-DefineLabel(CreateStmt *stmt, char labkind, const char *queryString)
+DefineLabel(CreateStmt *stmt, char labkind, const char *queryString,
+			bool is_fixed_id, int32 fixed_id)
 {
 	static char *validnsps[] = HEAP_RELOPT_NAMESPACES;
 	ObjectAddress reladdr;
@@ -255,7 +281,8 @@ DefineLabel(CreateStmt *stmt, char labkind, const char *queryString)
 	tablespaceId = GetDefaultTablespace(stmt->relation->relpersistence, false);
 
 	laboid = label_create_with_catalog(stmt->relation, reladdr.objectId,
-									   labkind, tablespaceId);
+									   labkind, tablespaceId, is_fixed_id,
+									   fixed_id);
 
 	GetSuperOids(stmt->inhRelations, labkind, &inheritOids);
 	AgInheritanceDependancy(laboid, inheritOids);
@@ -440,6 +467,9 @@ CheckLabelType(ObjectType type, Oid laboid, const char *command)
 {
 	HeapTuple tuple;
 	Form_ag_label labtup;
+
+	if (cypher_allow_unsafe_ddl)
+		return;
 
 	tuple = SearchSysCache1(LABELOID, ObjectIdGetDatum(laboid));
 	if (!HeapTupleIsValid(tuple))
@@ -682,4 +712,21 @@ deleteRelatedEdges(const char *vlab)
 
 		relation_close(rel, ShareLock);
 	}
+}
+
+static void
+SimpleProcessUtility(Node *node, const char *queryString, int stmt_location,
+					 int stmt_len)
+{
+	PlannedStmt *wrapper;
+
+	wrapper = makeNode(PlannedStmt);
+	wrapper->commandType = CMD_UTILITY;
+	wrapper->canSetTag = false;
+	wrapper->utilityStmt = node;
+	wrapper->stmt_location = stmt_location;
+	wrapper->stmt_len = stmt_len;
+
+	ProcessUtility(wrapper, queryString, PROCESS_UTILITY_SUBCOMMAND,
+				   NULL, NULL, None_Receiver, NULL);
 }

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -4915,6 +4915,7 @@ _copyCreateGraphStmt(const CreateGraphStmt *from)
 	COPY_STRING_FIELD(graphname);
 	COPY_NODE_FIELD(authrole);
 	COPY_SCALAR_FIELD(if_not_exists);
+	COPY_SCALAR_FIELD(kind);
 
 	return newnode;
 }
@@ -4930,6 +4931,8 @@ _copyCreateLabelStmt(const CreateLabelStmt *from)
 	COPY_NODE_FIELD(options);
 	COPY_STRING_FIELD(tablespacename);
 	COPY_SCALAR_FIELD(if_not_exists);
+	COPY_SCALAR_FIELD(only_base);
+	COPY_SCALAR_FIELD(fixed_id);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2958,6 +2958,7 @@ _equalCreateGraphStmt(const CreateGraphStmt *a, const CreateGraphStmt *b)
 	COMPARE_STRING_FIELD(graphname);
 	COMPARE_NODE_FIELD(authrole);
 	COMPARE_SCALAR_FIELD(if_not_exists);
+	COMPARE_SCALAR_FIELD(kind);
 
 	return true;
 }
@@ -2971,6 +2972,8 @@ _equalCreateLabelStmt(const CreateLabelStmt *a, const CreateLabelStmt *b)
 	COMPARE_NODE_FIELD(options);
 	COMPARE_STRING_FIELD(tablespacename);
 	COMPARE_SCALAR_FIELD(if_not_exists);
+	COMPARE_SCALAR_FIELD(only_base);
+	COMPARE_SCALAR_FIELD(fixed_id);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3871,6 +3871,8 @@ _outCreateLabelStmt(StringInfo str, const CreateLabelStmt *node)
 	WRITE_NODE_FIELD(options);
 	WRITE_STRING_FIELD(tablespacename);
 	WRITE_BOOL_FIELD(if_not_exists);
+	WRITE_BOOL_FIELD(only_base);
+	WRITE_INT_FIELD(fixed_id);
 }
 
 static void

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -602,6 +602,7 @@ static Node *wrapCypherWithSelect(Node *stmt);
 %type <ielem>	prop_idx_elem
 %type <boolean> opt_disable_index
 %type <ival>	reindex_target_label
+%type <ival>    elabel_or_vlabel
 
 /*
  * Cypher Query Language
@@ -15770,6 +15771,7 @@ CreateGraphStmt:
 					n->graphname = $3;
 					n->authrole = $5;
 					n->if_not_exists = false;
+					n->kind = CGSK_ALL;
 					$$ = (Node *) n;
 				}
 			| CREATE GRAPH ColId
@@ -15778,6 +15780,7 @@ CreateGraphStmt:
 					n->graphname = $3;
 					n->authrole = NULL;
 					n->if_not_exists = false;
+					n->kind = CGSK_ALL;
 					$$ = (Node *) n;
 				}
 			| CREATE GRAPH IF_P NOT EXISTS ColId AUTHORIZATION RoleSpec
@@ -15786,6 +15789,7 @@ CreateGraphStmt:
 					n->graphname = $6;
 					n->authrole = $8;
 					n->if_not_exists = true;
+					n->kind = CGSK_ALL;
 					$$ = (Node *) n;
 				}
 			| CREATE GRAPH IF_P NOT EXISTS ColId
@@ -15794,16 +15798,26 @@ CreateGraphStmt:
 					n->graphname = $6;
 					n->authrole = NULL;
 					n->if_not_exists = true;
+					n->kind = CGSK_ALL;
+					$$ = (Node *) n;
+				}
+			| CREATE GRAPH ONLY ColId
+				{
+					CreateGraphStmt *n = makeNode(CreateGraphStmt);
+					n->graphname = $4;
+					n->authrole = NULL;
+					n->if_not_exists = false;
+					n->kind = CGSK_SCHEMA;
 					$$ = (Node *) n;
 				}
 		;
 
 CreateLabelStmt:
-			CREATE OptNoLog VLABEL name opt_disable_index
+			CREATE OptNoLog elabel_or_vlabel name opt_disable_index
 			OptInherit opt_reloptions OptTableSpace
 				{
 					CreateLabelStmt *n = makeNode(CreateLabelStmt);
-					n->labelKind = LABEL_VERTEX;
+					n->labelKind = $3;
 					n->relation = makeRangeVar(NULL, $4, -1);
 					n->relation->relpersistence = $2;
 					n->inhRelations = $6;
@@ -15811,48 +15825,38 @@ CreateLabelStmt:
 					n->tablespacename = $8;
 					n->if_not_exists = false;
 					n->disable_index = $5;
+					n->only_base = false;
 					$$ = (Node *)n;
 				}
-			| CREATE OptNoLog VLABEL IF_P NOT EXISTS name opt_disable_index
+			| CREATE OptNoLog elabel_or_vlabel IF_P NOT EXISTS name opt_disable_index
 			OptInherit opt_reloptions OptTableSpace
 				{
 					CreateLabelStmt *n = makeNode(CreateLabelStmt);
-					n->labelKind = LABEL_VERTEX;
+					n->labelKind = $3;
 					n->relation = makeRangeVar(NULL, $7, -1);
 					n->relation->relpersistence = $2;
 					n->inhRelations = $9;
 					n->options = $10;
 					n->tablespacename = $11;
-					n->if_not_exists = true;
+					n->if_not_exists = $4;
 					n->disable_index = $8;
+					n->only_base = false;
 					$$ = (Node *)n;
 				}
-			| CREATE OptNoLog ELABEL name opt_disable_index
+			| CREATE OptNoLog elabel_or_vlabel ONLY name '(' Iconst ')' opt_disable_index
 			OptInherit opt_reloptions OptTableSpace
 				{
 					CreateLabelStmt *n = makeNode(CreateLabelStmt);
-					n->labelKind = LABEL_EDGE;
-					n->relation = makeRangeVar(NULL, $4, -1);
+					n->labelKind = $3;
+					n->relation = makeRangeVar(NULL, $5, -1);
 					n->relation->relpersistence = $2;
-					n->inhRelations = $6;
-					n->options = $7;
-					n->tablespacename = $8;
+					n->inhRelations = $10;
+					n->options = $11;
+					n->tablespacename = $12;
 					n->if_not_exists = false;
-					n->disable_index = $5;
-					$$ = (Node *)n;
-				}
-			| CREATE OptNoLog ELABEL IF_P NOT EXISTS name opt_disable_index
-			OptInherit opt_reloptions OptTableSpace
-				{
-					CreateLabelStmt *n = makeNode(CreateLabelStmt);
-					n->labelKind = LABEL_EDGE;
-					n->relation = makeRangeVar(NULL, $7, -1);
-					n->relation->relpersistence = $2;
-					n->inhRelations = $9;
-					n->options = $10;
-					n->tablespacename = $11;
-					n->if_not_exists = true;
-					n->disable_index = $8;
+					n->disable_index = $9;
+					n->only_base = true;
+					n->fixed_id = $7;
 					$$ = (Node *)n;
 				}
 		;
@@ -15861,6 +15865,11 @@ opt_disable_index:
 			DISABLE_P INDEX							{ $$ = true; }
 			| /*EMPTY*/								{ $$ = false; }
 		;
+
+elabel_or_vlabel:
+			ELABEL									{ $$ = LABEL_EDGE; }
+			| VLABEL								{ $$ = LABEL_VERTEX; }
+        ;
 
 AlterLabelStmt:
 			ALTER VLABEL name alter_label_cmds

--- a/src/backend/utils/adt/pg_upgrade_support.c
+++ b/src/backend/utils/adt/pg_upgrade_support.c
@@ -208,3 +208,23 @@ binary_upgrade_set_missing_value(PG_FUNCTION_ARGS)
 
 	PG_RETURN_VOID();
 }
+
+Datum
+binary_upgrade_set_next_ag_graph_oid(PG_FUNCTION_ARGS)
+{
+	Oid	ag_graph_oid = PG_GETARG_OID(0);
+
+	CHECK_IS_BINARY_UPGRADE;
+	binary_upgrade_next_ag_graph_oid = ag_graph_oid;
+	PG_RETURN_VOID();
+}
+
+Datum
+binary_upgrade_set_next_ag_label_oid(PG_FUNCTION_ARGS)
+{
+	Oid	ag_label_oid = PG_GETARG_OID(0);
+
+	CHECK_IS_BINARY_UPGRADE;
+	binary_upgrade_next_ag_label_oid = ag_label_oid;
+	PG_RETURN_VOID();
+}

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1995,6 +1995,17 @@ static struct config_bool ConfigureNamesBool[] =
 		NULL, NULL, NULL
 	},
 
+	{
+		{"cypher_allow_unsafe_ddl", PGC_USERSET, CLIENT_CONN_STATEMENT,
+			gettext_noop("Allows unsafe DDL on Cypher."),
+			NULL,
+			GUC_IS_NAME
+		},
+		&cypher_allow_unsafe_ddl,
+		false,
+		NULL, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL, NULL

--- a/src/bin/pg_dump/dumputils.c
+++ b/src/bin/pg_dump/dumputils.c
@@ -533,7 +533,8 @@ do { \
 	resetPQExpBuffer(privswgo);
 
 	if (strcmp(type, "TABLE") == 0 || strcmp(type, "SEQUENCE") == 0 ||
-		strcmp(type, "TABLES") == 0 || strcmp(type, "SEQUENCES") == 0)
+		strcmp(type, "TABLES") == 0 || strcmp(type, "SEQUENCES") == 0 ||
+		strcmp(type, "ELABEL") == 0 || strcmp(type, "VLABEL") == 0)
 	{
 		CONVERT_PRIV('r', "SELECT");
 
@@ -568,7 +569,8 @@ do { \
 	else if (strcmp(type, "LANGUAGE") == 0)
 		CONVERT_PRIV('U', "USAGE");
 	else if (strcmp(type, "SCHEMA") == 0 ||
-			 strcmp(type, "SCHEMAS") == 0)
+			 strcmp(type, "SCHEMAS") == 0 ||
+			 strcmp(type, "GRAPH") == 0)
 	{
 		CONVERT_PRIV('C', "CREATE");
 		CONVERT_PRIV('U', "USAGE");
@@ -1058,61 +1060,4 @@ makeAlterConfigCommand(PGconn *conn, const char *configitem,
 	appendPQExpBufferStr(buf, ";\n");
 
 	pg_free(mine);
-}
-
-/*
- * Checks the passed configuration option, to determine if it is the graph_path
- * configuration option. format: graph_path=path, possibly string quoted.
- */
-bool
-isGraphPathConfig(const char *config)
-{
-	char *pos;
-	char *mine;
-	bool isGraphPath;
-
-	mine = pg_strdup(config);
-	pos = strchr(mine, '=');
-	if (pos == NULL)
-	{
-		free(mine);
-		return false;
-	}
-
-	if (*mine == '"' || *mine == '\'')
-		mine++;
-
-	*pos = 0;
-	isGraphPath = strcmp(mine, "graph_path") == 0;
-	free(mine);
-	return isGraphPath;
-}
-
-/*
- * Extracts the value of a configuration options
- * Format: config_value=config_value, possibly string quoted
- */
-char *
-extractConfigValue(const char *config)
-{
-	char *pos;
-	char *mine;
-	char *return_value;
-
-	mine = pg_strdup(config);
-	pos = strchr(mine, '=');
-	if (pos == NULL)
-	{
-		free(mine);
-		return NULL;
-	}
-
-	if (pos[strlen(pos) - 1] == '"' || pos[strlen(pos) - 1] == '\'')
-		pos[strlen(pos) - 1] = '\0';
-
-	*pos = 0;
-	return_value = pg_strdup(pos + 1);
-	free(mine);
-
-	return return_value;
 }

--- a/src/bin/pg_dump/dumputils.h
+++ b/src/bin/pg_dump/dumputils.h
@@ -66,7 +66,4 @@ extern void makeAlterConfigCommand(PGconn *conn, const char *configitem,
 								   const char *type2, const char *name2,
 								   PQExpBuffer buf);
 
-extern bool isGraphPathConfig(const char *config);
-extern char *extractConfigValue(const char *config);
-
 #endif							/* DUMPUTILS_H */

--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -80,7 +80,7 @@ static void _doSetSessionAuth(ArchiveHandle *AH, const char *user);
 static void _reconnectToDB(ArchiveHandle *AH, const char *dbname);
 static void _becomeUser(ArchiveHandle *AH, const char *user);
 static void _becomeOwner(ArchiveHandle *AH, TocEntry *te);
-static void _selectOutputSchema(ArchiveHandle *AH, const char *schemaName, teSection sec);
+static void _selectOutputSchema(ArchiveHandle *AH, const char *schemaName);
 static void _selectTablespace(ArchiveHandle *AH, const char *tablespace);
 static void _selectTableAccessMethod(ArchiveHandle *AH, const char *tableam);
 static void processEncodingEntry(ArchiveHandle *AH, TocEntry *te);
@@ -515,7 +515,7 @@ RestoreArchive(Archive *AHX)
 				pg_log_info("dropping %s %s", te->desc, te->tag);
 				/* Select owner and schema as necessary */
 				_becomeOwner(AH, te);
-				_selectOutputSchema(AH, te->namespace, te->section);
+				_selectOutputSchema(AH, te->namespace);
 
 				/*
 				 * Now emit the DROP command, if the object has one.  Note we
@@ -638,10 +638,6 @@ RestoreArchive(Archive *AHX)
 		if (AH->currSchema)
 			free(AH->currSchema);
 		AH->currSchema = NULL;
-
-		if (AH->currGraph)
-			free(AH->currGraph);
-		AH->currGraph = NULL;
 	}
 
 	if (parallel_mode)
@@ -793,7 +789,9 @@ restore_toc_entry(ArchiveHandle *AH, TocEntry *te, bool is_parallel)
 		_printTocEntry(AH, te, false);
 		defnDumped = true;
 
-		if (strcmp(te->desc, "TABLE") == 0)
+		if (strcmp(te->desc, "TABLE") == 0 ||
+			strcmp(te->desc, "ELABEL") == 0 ||
+			strcmp(te->desc, "VLABEL") == 0)
 		{
 			if (AH->lastErrorTE == te)
 			{
@@ -874,7 +872,7 @@ restore_toc_entry(ArchiveHandle *AH, TocEntry *te, bool is_parallel)
 				{
 					pg_log_info("processing %s", te->desc);
 
-					_selectOutputSchema(AH, "pg_catalog", te->section);
+					_selectOutputSchema(AH, "pg_catalog");
 
 					/* Send BLOB COMMENTS data to ExecuteSimpleCommands() */
 					if (strcmp(te->desc, "BLOB COMMENTS") == 0)
@@ -890,7 +888,7 @@ restore_toc_entry(ArchiveHandle *AH, TocEntry *te, bool is_parallel)
 
 					/* Select owner and schema as necessary */
 					_becomeOwner(AH, te);
-					_selectOutputSchema(AH, te->namespace, te->section);
+					_selectOutputSchema(AH, te->namespace);
 
 					pg_log_info("processing data for table \"%s.%s\"",
 								te->namespace, te->tag);
@@ -2324,7 +2322,6 @@ _allocAH(const char *FileSpec, const ArchiveFormat fmt,
 
 	AH->currUser = NULL;		/* unknown */
 	AH->currSchema = NULL;		/* ditto */
-	AH->currGraph = NULL;		/* ditto */
 	AH->currTablespace = NULL;	/* ditto */
 	AH->currTableAm = NULL;		/* ditto */
 
@@ -2972,7 +2969,9 @@ _tocEntryRequired(TocEntry *te, teSection curSection, ArchiveHandle *AH)
 				strcmp(te->desc, "MATERIALIZED VIEW") == 0 ||
 				strcmp(te->desc, "MATERIALIZED VIEW DATA") == 0 ||
 				strcmp(te->desc, "SEQUENCE") == 0 ||
-				strcmp(te->desc, "SEQUENCE SET") == 0)
+				strcmp(te->desc, "SEQUENCE SET") == 0 ||
+				strcmp(te->desc, "ELABEL") == 0 ||
+				strcmp(te->desc, "VLABEL") == 0)
 			{
 				if (!ropt->selTable)
 					return 0;
@@ -3165,6 +3164,8 @@ _doSetFixedOutputState(ArchiveHandle *AH)
 	else
 		ahprintf(AH, "SET row_security = off;\n");
 
+	ahprintf(AH, "SET cypher_allow_unsafe_ddl = on;\n");
+
 	ahprintf(AH, "\n");
 }
 
@@ -3250,11 +3251,6 @@ _reconnectToDB(ArchiveHandle *AH, const char *dbname)
 	if (AH->currSchema)
 		free(AH->currSchema);
 	AH->currSchema = NULL;
-
-	if (AH->currGraph)
-		free(AH->currGraph);
-	AH->currGraph = NULL;
-
 	if (AH->currTablespace)
 		free(AH->currTablespace);
 	AH->currTablespace = NULL;
@@ -3309,7 +3305,7 @@ _becomeOwner(ArchiveHandle *AH, TocEntry *te)
  * in the target database.
  */
 static void
-_selectOutputSchema(ArchiveHandle *AH, const char *schemaName, teSection sec)
+_selectOutputSchema(ArchiveHandle *AH, const char *schemaName)
 {
 	PQExpBuffer qry;
 
@@ -3322,15 +3318,9 @@ _selectOutputSchema(ArchiveHandle *AH, const char *schemaName, teSection sec)
 	if (AH->public.searchpath)
 		return;
 
-	if (!schemaName || *schemaName == '\0')
-		return;
-	else if	(AH->currSchema && strcmp(AH->currSchema, schemaName) == 0)
-	{
-		if (sec < SECTION_POST_DATA)
-			return;					/* no need to do anything */
-		else if (AH->currGraph && strcmp(AH->currGraph, schemaName) == 0)
-			return;
-	}
+	if (!schemaName || *schemaName == '\0' ||
+		(AH->currSchema && strcmp(AH->currSchema, schemaName) == 0))
+		return;					/* no need to do anything */
 
 	qry = createPQExpBuffer();
 
@@ -3338,32 +3328,6 @@ _selectOutputSchema(ArchiveHandle *AH, const char *schemaName, teSection sec)
 					  fmtId(schemaName));
 	if (strcmp(schemaName, "pg_catalog") != 0)
 		appendPQExpBufferStr(qry, ", pg_catalog");
-
-	if (sec == SECTION_POST_DATA)
-	{
-		PQExpBuffer tmp;
-		PGresult   *res;
-
-		/* if the given schema is a graph, set graph_path too */
-
-		tmp = createPQExpBuffer();
-		appendPQExpBuffer(tmp,
-						  "SELECT 1 FROM pg_catalog.ag_graph WHERE graphname = '%s'",
-						  schemaName);
-		res = ExecuteSqlQuery(&AH->public, tmp->data, PGRES_TUPLES_OK);
-
-		if (PQntuples(res) > 0)
-		{
-			appendPQExpBuffer(qry, ";\nSET graph_path = %s", fmtId(schemaName));
-
-			if (AH->currGraph)
-				free(AH->currGraph);
-			AH->currGraph = pg_strdup(schemaName);
-		}
-
-		PQclear(res);
-		destroyPQExpBuffer(tmp);
-	}
 
 	if (RestoringToDB(AH))
 	{
@@ -3527,11 +3491,19 @@ _getObjectDescription(PQExpBuffer buf, TocEntry *te, ArchiveHandle *AH)
 		strcmp(type, "SERVER") == 0 ||
 		strcmp(type, "PUBLICATION") == 0 ||
 		strcmp(type, "SUBSCRIPTION") == 0 ||
-		strcmp(type, "USER MAPPING") == 0)
+		strcmp(type, "USER MAPPING") == 0 ||
+		strcmp(type, "GRAPH") == 0)
 	{
 		appendPQExpBuffer(buf, "%s ", type);
 		if (te->namespace && *te->namespace)
 			appendPQExpBuffer(buf, "%s.", fmtId(te->namespace));
+		appendPQExpBufferStr(buf, fmtId(te->tag));
+		return;
+	}
+
+	if (strcmp(type, "ELABEL") == 0 || strcmp(type, "VLABEL") == 0)
+	{
+		appendPQExpBuffer(buf, "%s ", type);
 		appendPQExpBufferStr(buf, fmtId(te->tag));
 		return;
 	}
@@ -3590,7 +3562,7 @@ _printTocEntry(ArchiveHandle *AH, TocEntry *te, bool isData)
 
 	/* Select owner, schema, tablespace and default AM as necessary */
 	_becomeOwner(AH, te);
-	_selectOutputSchema(AH, te->namespace, te->section);
+	_selectOutputSchema(AH, te->namespace);
 	_selectTablespace(AH, te->tablespace);
 	_selectTableAccessMethod(AH, te->tableam);
 
@@ -3661,6 +3633,10 @@ _printTocEntry(ArchiveHandle *AH, TocEntry *te, bool isData)
 	{
 		ahprintf(AH, "CREATE SCHEMA %s;\n\n\n", fmtId(te->tag));
 	}
+	else if (ropt->noOwner && strcmp(te->desc, "GRAPH") == 0)
+	{
+		ahprintf(AH, "CREATE GRAPH ONLY %s;\n\n\n", fmtId(te->tag));
+	}
 	else
 	{
 		if (te->defn && strlen(te->defn) > 0)
@@ -3703,7 +3679,10 @@ _printTocEntry(ArchiveHandle *AH, TocEntry *te, bool isData)
 			strcmp(te->desc, "SERVER") == 0 ||
 			strcmp(te->desc, "STATISTICS") == 0 ||
 			strcmp(te->desc, "PUBLICATION") == 0 ||
-			strcmp(te->desc, "SUBSCRIPTION") == 0)
+			strcmp(te->desc, "SUBSCRIPTION") == 0 ||
+			strcmp(te->desc, "GRAPH") == 0 ||
+			strcmp(te->desc, "ELABEL") == 0 ||
+			strcmp(te->desc, "VLABEL") == 0)
 		{
 			PQExpBuffer temp = createPQExpBuffer();
 
@@ -4067,11 +4046,6 @@ restore_toc_entries_prefork(ArchiveHandle *AH, TocEntry *pending_list)
 	if (AH->currSchema)
 		free(AH->currSchema);
 	AH->currSchema = NULL;
-
-	if (AH->currGraph)
-		free(AH->currGraph);
-	AH->currGraph = NULL;
-
 	if (AH->currTablespace)
 		free(AH->currTablespace);
 	AH->currTablespace = NULL;
@@ -4761,7 +4735,9 @@ identify_locking_dependencies(ArchiveHandle *AH, TocEntry *te)
 
 		if (depid <= AH->maxDumpId && AH->tocsByDumpId[depid] != NULL &&
 			((strcmp(AH->tocsByDumpId[depid]->desc, "TABLE DATA") == 0) ||
-			 strcmp(AH->tocsByDumpId[depid]->desc, "TABLE") == 0))
+			  strcmp(AH->tocsByDumpId[depid]->desc, "TABLE") == 0 ||
+			  strcmp(AH->tocsByDumpId[depid]->desc, "ELABEL") == 0 ||
+			  strcmp(AH->tocsByDumpId[depid]->desc, "VLABEL") == 0 ))
 			lockids[nlockids++] = depid;
 	}
 
@@ -4872,7 +4848,6 @@ CloneArchive(ArchiveHandle *AH)
 	clone->connCancel = NULL;
 	clone->currUser = NULL;
 	clone->currSchema = NULL;
-	clone->currGraph = NULL;
 	clone->currTablespace = NULL;
 
 	/* savedPassword must be local in case we change it while connecting */
@@ -4962,8 +4937,6 @@ DeCloneArchive(ArchiveHandle *AH)
 		free(AH->currUser);
 	if (AH->currSchema)
 		free(AH->currSchema);
-	if (AH->currGraph)
-		free(AH->currGraph);
 	if (AH->currTablespace)
 		free(AH->currTablespace);
 	if (AH->currTableAm)

--- a/src/bin/pg_dump/pg_backup_archiver.h
+++ b/src/bin/pg_dump/pg_backup_archiver.h
@@ -342,7 +342,6 @@ struct _archiveHandle
 	/* these vars track state to avoid sending redundant SET commands */
 	char	   *currUser;		/* current username, or NULL if unknown */
 	char	   *currSchema;		/* current schema, or NULL */
-	char	   *currGraph;		/* current graph, or NULL */
 	char	   *currTablespace; /* current tablespace, or NULL */
 	char	   *currTableAm;	/* current table access method, or NULL */
 

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -149,6 +149,8 @@ typedef struct _namespaceInfo
 	char	   *rnspacl;
 	char	   *initnspacl;
 	char	   *initrnspacl;
+	bool		ag_isgraph;
+	Oid			ag_graphoid;
 } NamespaceInfo;
 
 typedef struct _extensionInfo
@@ -326,6 +328,9 @@ typedef struct _tableInfo
 	char	   *partbound;		/* partition bound definition */
 	bool		needs_override; /* has GENERATED ALWAYS AS IDENTITY */
 	char	   *amname;			/* relation access method */
+	char		ag_labkind;
+	Oid 		ag_laboid;
+	int			ag_labid;
 
 	/*
 	 * Stuff computed only for dumpable tables.
@@ -373,6 +378,7 @@ typedef struct _indxInfo
 	Oid			parentidx;		/* if partitioned, parent index OID */
 	/* if there is an associated constraint object, its dumpId: */
 	DumpId		indexconstraint;
+	bool		ispropidx;		/* Is it cypher property index? */
 } IndxInfo;
 
 typedef struct _indexAttachInfo

--- a/src/bin/pg_upgrade/test.sh
+++ b/src/bin/pg_upgrade/test.sh
@@ -252,6 +252,7 @@ case $testhost in
 esac
 
 pg_dumpall --no-sync -f "$temp_root"/dump2.sql || pg_dumpall2_status=$?
+psql -d regression -c "SELECT regather_graphmeta()"
 psql -d regression -c "SELECT * FROM ag_graphmeta_view" -o "$temp_root"/meta2.out
 pg_ctl -m fast stop
 

--- a/src/include/catalog/ag_graph_fn.h
+++ b/src/include/catalog/ag_graph_fn.h
@@ -14,6 +14,7 @@
 
 extern char *graph_path;
 extern bool enableGraphDML;
+extern bool cypher_allow_unsafe_ddl;
 
 extern char *get_graph_path(bool lookup_cache);
 extern Oid get_graph_path_oid(void);

--- a/src/include/catalog/ag_label_fn.h
+++ b/src/include/catalog/ag_label_fn.h
@@ -13,7 +13,8 @@
 #include "nodes/parsenodes.h"
 
 extern Oid label_create_with_catalog(RangeVar *label, Oid relid, char labkind,
-									 Oid labtablespace);
+									 Oid labtablespace, bool is_fixed_id,
+									 int32 fixed_id);
 extern void label_drop_with_catalog(Oid laboid);
 
 #endif	/* AG_LABEL_FN_H */

--- a/src/include/catalog/binary_upgrade.h
+++ b/src/include/catalog/binary_upgrade.h
@@ -27,4 +27,7 @@ extern PGDLLIMPORT Oid binary_upgrade_next_pg_authid_oid;
 
 extern PGDLLIMPORT bool binary_upgrade_record_init_privs;
 
+extern PGDLLIMPORT Oid binary_upgrade_next_ag_graph_oid;
+extern PGDLLIMPORT Oid binary_upgrade_next_ag_label_oid;
+
 #endif							/* BINARY_UPGRADE_H */

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -11073,4 +11073,14 @@
 { oid => '7247', descr => 'map input to jsonb (cypher)',
   proname => 'cypher_to_jsonb', provolatile => 'i', prorettype => 'jsonb',
   proargtypes => 'anyelement', prosrc => 'cypher_to_jsonb' },
+
+# supports for agensgraph binary upgrade
+{ oid => '8001', descr => 'for use by pg_upgrade',
+  proname => 'binary_upgrade_set_next_ag_graph_oid', provolatile => 'v',
+  proparallel => 'r', prorettype => 'void', proargtypes => 'oid',
+  prosrc => 'binary_upgrade_set_next_ag_graph_oid' },
+{ oid => '8002', descr => 'for use by pg_upgrade',
+  proname => 'binary_upgrade_set_next_ag_label_oid', provolatile => 'v',
+  proparallel => 'r', prorettype => 'void', proargtypes => 'oid',
+  prosrc => 'binary_upgrade_set_next_ag_label_oid' },
 ]

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3572,6 +3572,15 @@ typedef struct DropSubscriptionStmt
  * Agens Graph related node structures
  ****************************************************************************/
 
+typedef enum CreateGraphStmtKind
+{
+	CGSK_ALL = 0x1 + 0x2 + 0x4 + 0x8,
+	CGSK_SCHEMA = 0x1,
+	CGSK_ELABEL = 0x2,
+	CGSK_VLABEL = 0x4,
+	CGSK_SEQUENCE = 0x8
+} CreateGraphStmtKind;
+
 /* CREATE GRAPH ... */
 typedef struct CreateGraphStmt
 {
@@ -3579,6 +3588,7 @@ typedef struct CreateGraphStmt
 	char	   *graphname;		/* the name of the graph to create */
 	RoleSpec   *authrole;		/* the owner of the created graph */
 	bool		if_not_exists;	/* just do nothing if graph already exists? */
+	CreateGraphStmtKind	kind;
 } CreateGraphStmt;
 
 typedef enum LabelKind
@@ -3598,6 +3608,10 @@ typedef struct CreateLabelStmt
 	char	   *tablespacename; /* table space to use, or NULL */
 	bool		if_not_exists;	/* just do nothing if it already exists? */
 	bool		disable_index;	/* create invalid and not ready index if true */
+
+	/* Supports for binary upgrade */
+	bool		only_base;
+	int			fixed_id;
 } CreateLabelStmt;
 
 /* ALTER VLABEL/ELABEL ... */

--- a/src/include/parser/parse_utilcmd.h
+++ b/src/include/parser/parse_utilcmd.h
@@ -32,7 +32,9 @@ extern IndexStmt *generateClonedIndexStmt(RangeVar *heapRel,
 										  const AttrNumber *attmap, int attmap_length,
 										  Oid *constraintOid);
 
-extern List *transformCreateGraphStmt(CreateGraphStmt *stmt);
+extern CreateSeqStmt *makeDefaultCreateAGLabelSeqStmt(char *graph_name, int location);
+extern CreateLabelStmt *makeDefaultCreateAGLabelStmt(char *graph_name,
+													 LabelKind labKind, int location);
 extern List *transformCreateLabelStmt(CreateLabelStmt *labelStmt,
 									  const char *queryString);
 extern char getLabelKind(char *labname, Oid graphid);

--- a/src/test/regress/expected/cypher_finalize.out
+++ b/src/test/regress/expected/cypher_finalize.out
@@ -1,0 +1,1 @@
+ALTER DATABASE regression SET GRAPH_PATH TO ddl;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -144,3 +144,6 @@ test: sql_restriction
 
 # run property index
 test: propertyindex
+
+# run cypher finalize
+test: cypher_finalize

--- a/src/test/regress/sql/cypher_finalize.sql
+++ b/src/test/regress/sql/cypher_finalize.sql
@@ -1,0 +1,1 @@
+ALTER DATABASE regression SET GRAPH_PATH TO ddl;


### PR DESCRIPTION
Previously, Graph data did not support binary-upgrade. Also, in regular dumps,
there were mixed up with giddy codes. This made the upgrade uncomfortable.

So, adds a small unit of graph DDL and GUC for upgrade and change it to use.

Syntax
- CREATE ONLY (V|E)LABEL <NAME>(ID)
  - DO NOT USE GRAPH SEQUENCE
  - DO NOT MAKE CONSTRAINTS
  - DO NOT GENERATE NEW ID
- CREATE BASE GRAPH <NAME>
  - DO NOT MAKE BASE (V|E)LABEL
  - DO NOT MAKE SEQUENCE

GUC
- cypher_allow_unsafe_ddl

Functions
- binary_upgrade_set_next_ag_graph_oid ( OID )
- binary_upgrade_set_next_ag_label_oid ( OID )