### PR TITLE
Fix error case for pg_restore (LABEL Restore).

### DIFF
--- a/src/backend/commands/dropcmds.c
+++ b/src/backend/commands/dropcmds.c
@@ -105,34 +105,10 @@ RemoveObjects(DropStmt *stmt)
 						 errhint("Use DROP AGGREGATE to drop aggregate functions.")));
 		}
 
-		if (stmt->removeType == OBJECT_VLABEL)
+		if (stmt->removeType == OBJECT_VLABEL ||
+			stmt->removeType == OBJECT_ELABEL)
 		{
-			CheckLabelType(OBJECT_VLABEL, address.objectId, "DROP");
-
-			if (stmt->behavior == DROP_CASCADE)
-			{
-				RangeVar	*lab = makeRangeVarFromNameList(castNode(List, object));
-
-				deleteRelatedEdges(lab->relname);
-
-				agstat_drop_vlabel(lab->relname);
-			}
-			else
-			{
-				Assert(stmt->behavior == DROP_RESTRICT);
-
-				if (!isEmptyLabel(NameListToString(castNode(List, object))))
-				{
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							 errmsg("cannot drop %s because it is not empty.",
-									NameListToString(castNode(List, object)))));
-				}
-			}
-		}
-		else if (stmt->removeType == OBJECT_ELABEL)
-		{
-			CheckLabelType(OBJECT_ELABEL, address.objectId, "DROP");
+			CheckLabelType(stmt->removeType, address.objectId, "DROP");
 
 			if (stmt->behavior == DROP_RESTRICT &&
 				!isEmptyLabel(NameListToString(castNode(List, object))))
@@ -146,7 +122,15 @@ RemoveObjects(DropStmt *stmt)
 			{
 				RangeVar	*lab = makeRangeVarFromNameList(castNode(List, object));
 
-				agstat_drop_elabel(lab->relname);
+				if (stmt->removeType == OBJECT_VLABEL)
+				{
+					deleteRelatedEdges(lab->relname);
+					agstat_drop_vlabel(lab->relname);
+				}
+				else
+				{
+					agstat_drop_elabel(lab->relname);
+				}
 			}
 		}
 		else if (stmt->removeType == OBJECT_GRAPH)

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -18867,7 +18867,13 @@ dumpLabelSchema(Archive *fout, TableInfo *tblinfo)
 	setGraphPath(q, tblinfo->dobj.namespace);
 	setGraphPath(delq, tblinfo->dobj.namespace);
 
-	appendPQExpBuffer(delq, "DROP %s %s;\n", reltypename, qrelname);
+	/* =====================================================
+	 * If it is not cascade, then error occurs.
+	 * "cannot drop <LABEL_NAME> because it is not empty."
+	 * See RemoveObjects()
+	 * =====================================================
+	 */
+	appendPQExpBuffer(delq, "DROP %s %s CASCADE;\n", reltypename, qrelname);
 
 	if (dopt->binary_upgrade)
 	{


### PR DESCRIPTION
AgensGraph cannot drop non empty label(table) without CASCADE option. so, When
use pg_restore with --clean flag, uses CASCADE option on labels.