### PR TITLE
AGV2-41 Corrects windows build failure.

### DIFF
--- a/src/tools/msvc/Mkvcbuild.pm
+++ b/src/tools/msvc/Mkvcbuild.pm
@@ -54,7 +54,7 @@ my @contrib_excludes = (
 
 # Set of variables for frontend modules
 my $frontend_defines = { 'initdb' => 'FRONTEND' };
-my @frontend_uselibpq = ('pg_ctl', 'ag_ctl', 'pg_upgrade', 'pgbench', 'psql', 'initdb');
+my @frontend_uselibpq = ('pg_ctl', 'pg_upgrade', 'pgbench', 'psql', 'initdb');
 my @frontend_uselibpgport = (
 	'pg_archivecleanup', 'pg_test_fsync',
 	'pg_test_timing',    'pg_upgrade',
@@ -74,7 +74,7 @@ my $frontend_extraincludes = {
 	'psql'   => ['src/backend']
 };
 my $frontend_extrasource = {
-	'psql' => ['src/bin/psql/psqlscanslash.l'],
+	'psql' => ['src/bin/psql/psqlscanslash.l', 'src/bin/psql/common.c'],
 	'pgbench' =>
 	  [ 'src/bin/pgbench/exprscan.l', 'src/bin/pgbench/exprparse.y' ]
 };
@@ -422,6 +422,12 @@ sub mkvcbuild
 	$zic->AddFiles('src/timezone', 'zic.c');
 	$zic->AddDirResourceFile('src/timezone');
 	$zic->AddReference($libpgcommon, $libpgport);
+
+	my $agens = AddSimpleFrontend('psql', 1);
+	$agens->{name} = 'agens';
+
+	my $ag_ctl = AddSimpleFrontend('pg_ctl', 1);
+	$ag_ctl->{name} = 'ag_ctl';
 
 	if (!$solution->{options}->{xml})
 	{

--- a/src/tools/msvc/Solution.pm
+++ b/src/tools/msvc/Solution.pm
@@ -152,6 +152,8 @@ sub GenerateFiles
 	my $package_bugreport;
 	my $package_url;
 	my ($majorver, $minorver);
+	my $ag_version;
+	my $ag_comp_version;
 
 	# Parse configure.in to get version numbers
 	open(my $c, '<', "configure.in")
@@ -175,6 +177,18 @@ sub GenerateFiles
 			}
 			$majorver = sprintf("%d", $1);
 			$minorver = sprintf("%d", $2 ? $2 : 0);
+		}
+
+		# AG_VERSION
+		if (/\[AG_VERSION=([^\]]+)\]/)
+		{
+			$ag_version = $1;
+		}
+
+		# AG_COMP_VERSION
+		if (/\[AG_COMP_VERSION=([^\]]+)\]/)
+		{
+			$ag_comp_version = $1;
 		}
 	}
 	close($c);
@@ -497,7 +511,12 @@ sub GenerateFiles
 		pg_restrict       => '__restrict',
 		# not defined, because it'd conflict with __declspec(restrict)
 		restrict => undef,
-		typeof   => undef,);
+		typeof   => undef,
+		# AgensGraph
+		AG_COMP_VERSION	=> qq{"$ag_comp_version"},
+		AG_VERSION		=> qq{"$ag_version"},
+		# We will not care about revision on Windows
+		AG_GIT_REVISION	=> qq{"win_no_rev"},);
 
 	if ($self->{options}->{uuid})
 	{


### PR DESCRIPTION
fix: Corrects windows build failure.

- (Windows) Corrects AG_VERSION, AG_COMP_VERSION, AG_GIT_REVISION definition.
- (Windows) Copy psql as agens, pg_ctl as ag_ctl.


**_Need to applied AG 2.5~2.13._** 