### PR TITLE
AGV2-23 Implement head(), last(), tail() for array type. #525

### DIFF
--- a/src/backend/parser/parse_cypher_expr.c
+++ b/src/backend/parser/parse_cypher_expr.c
@@ -1120,6 +1120,9 @@ func_match_argtypes_jsonb(int nargs, Oid argtypes[FUNC_MAX_ARGS],
 		current_candidate->next = *candidates;
 		*candidates = current_candidate;
 		ncandidates++;
+                
+                if(current_candidate->oid == F_ARRAY_HEAD || current_candidate->oid == F_ARRAY_LAST || current_candidate->oid == F_ARRAY_TAIL) 
+                  return 1; 
 	}
 
 	return ncandidates;

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -11082,4 +11082,15 @@
   proname => 'binary_upgrade_set_next_ag_label_oid', provolatile => 'v',
   proparallel => 'r', prorettype => 'void', proargtypes => 'oid',
   prosrc => 'binary_upgrade_set_next_ag_label_oid' },
+
+
+{ oid => '8003', descr => 'the first element in a list',
+proname => 'head', prorettype => 'anyelement', proargtypes => 'anyarray',
+  prosrc => 'array_head' },
+{ oid => '8004', descr => 'the last element in a list',
+proname => 'last', prorettype => 'anyelement', proargtypes => 'anyarray',
+  prosrc => 'array_last' },
+{ oid => '8005', descr => 'a list except the first element',
+proname => 'tail', prorettype => 'anyarray', proargtypes => 'anyarray',
+  prosrc => 'array_tail' },        
 ]

--- a/src/include/utils/cypher_funcs.h
+++ b/src/include/utils/cypher_funcs.h
@@ -68,5 +68,8 @@ extern Datum jsonb_string_regex(PG_FUNCTION_ARGS);
 
 /* utility */
 extern Datum get_last_graph_write_stats(PG_FUNCTION_ARGS);
+extern Datum array_head(PG_FUNCTION_ARGS);
+extern Datum array_last(PG_FUNCTION_ARGS);
+extern Datum array_tail(PG_FUNCTION_ARGS);
 
 #endif	/* CYPHER_FUNCS_H */

--- a/src/test/regress/expected/cypher_dml2.out
+++ b/src/test/regress/expected/cypher_dml2.out
@@ -29,10 +29,51 @@ RETURN count(p);
  0
 (1 row)
 
+-- AGV2-26, head/tail/last returns array
+CREATE(:v_user{name:'userA'});
+CREATE(:v_title{name:'TitleA'});
+CREATE(:v_type{name:'TypeA'});
+CREATE(:v_sub{name:'SubA'});
+MATCH(v1:v_user{name:'userA'}), (v2:v_title{name:'TitleA'})
+CREATE (v1)-[:e_user_title{name:'(1)', val:1}]->(v2);
+MATCH(v1:v_title{name:'TitleA'}), (v2:v_type{name:'TypeA'})
+CREATE (v1)-[:e_title_type{name:'(2)', val:2}]->(v2);
+MATCH(v1:v_type{name:'TypeA'}), (v2:v_sub{name:'SubA'})
+CREATE (v1)-[:e_title_type{name:'(3)', val:3}]->(v2);
+MATCH(n)-[e*3]->(n3) RETURN e;
+                                                                                e                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [e_user_title[9.1][5.1,6.1]{"val": 1, "name": "(1)"},e_title_type[10.1][6.1,7.1]{"val": 2, "name": "(2)"},e_title_type[10.2][7.1,8.1]{"val": 3, "name": "(3)"}]
+(1 row)
+
+MATCH(n)-[e*3]->(n3) RETURN head(e);
+                        head                         
+-----------------------------------------------------
+ e_user_title[9.1][5.1,6.1]{"val": 1, "name": "(1)"}
+(1 row)
+
+MATCH(n)-[e*3]->(n3) RETURN tail(e);
+                                                    tail                                                     
+-------------------------------------------------------------------------------------------------------------
+ [e_title_type[10.1][6.1,7.1]{"val": 2, "name": "(2)"},e_title_type[10.2][7.1,8.1]{"val": 3, "name": "(3)"}]
+(1 row)
+
+MATCH(n)-[e*3]->(n3) RETURN last(e);
+                         last                         
+------------------------------------------------------
+ e_title_type[10.2][7.1,8.1]{"val": 3, "name": "(3)"}
+(1 row)
+
 DROP GRAPH cypher_dml2 CASCADE;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 11 other objects
 DETAIL:  drop cascades to sequence cypher_dml2.ag_label_seq
 drop cascades to vlabel ag_vertex
 drop cascades to elabel ag_edge
 drop cascades to vlabel v1
 drop cascades to elabel e1
+drop cascades to vlabel v_user
+drop cascades to vlabel v_title
+drop cascades to vlabel v_type
+drop cascades to vlabel v_sub
+drop cascades to elabel e_user_title
+drop cascades to elabel e_title_type

--- a/src/test/regress/sql/cypher_dml2.sql
+++ b/src/test/regress/sql/cypher_dml2.sql
@@ -20,4 +20,25 @@ MATCH p=(n1)-[r:e1*2]->(n2)
 WHERE all(x in r where x.id is null)
 RETURN count(p);
 
+-- AGV2-26, head/tail/last returns array
+CREATE(:v_user{name:'userA'});
+CREATE(:v_title{name:'TitleA'});
+CREATE(:v_type{name:'TypeA'});
+CREATE(:v_sub{name:'SubA'});
+
+MATCH(v1:v_user{name:'userA'}), (v2:v_title{name:'TitleA'})
+CREATE (v1)-[:e_user_title{name:'(1)', val:1}]->(v2);
+
+MATCH(v1:v_title{name:'TitleA'}), (v2:v_type{name:'TypeA'})
+CREATE (v1)-[:e_title_type{name:'(2)', val:2}]->(v2);
+
+MATCH(v1:v_type{name:'TypeA'}), (v2:v_sub{name:'SubA'})
+CREATE (v1)-[:e_title_type{name:'(3)', val:3}]->(v2);
+
+MATCH(n)-[e*3]->(n3) RETURN e;
+MATCH(n)-[e*3]->(n3) RETURN head(e);
+MATCH(n)-[e*3]->(n3) RETURN tail(e);
+MATCH(n)-[e*3]->(n3) RETURN last(e);
+
+
 DROP GRAPH cypher_dml2 CASCADE;


### PR DESCRIPTION
AGV2-23 Implement `head()`, `last()`, `tail()` for array type. #525 

Previously, all data was cast as JSONB to process the value. however, `head()`,
`last()`, `tail()` function also casting values that should not be casting into
JSONB, resulting in unexpected results. so, implement a separate function for
the Array type.
