### PR TITLE
Fixed initdb error without -D options

### DIFF
--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -2411,7 +2411,11 @@ setup_pgdata(void)
 
 	if (!pg_data)
 	{
-		pgdata_get_env = getenv("PGDATA");
+		pgdata_get_env = getenv("AGDATA");
+		if (!pgdata_get_env || !strlen(pgdata_get_env))
+		{
+			pgdata_get_env = getenv("PGDATA");
+		}
 		if (pgdata_get_env && strlen(pgdata_get_env))
 		{
 			/* PGDATA found */


### PR DESCRIPTION
Fixed an error where the database was not created when initdb was used without the -D option.

And if you don't use the -D option, you need to add the AGDATA environment.