### PR TITLE
chore: Resolve warnings in the build

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -18,7 +18,7 @@ jobs:
         run: ./configure --enable-cassert --enable-debug
 
       - name: Build
-        run: make -j$(nproc) -s > /dev/null
+        run: make -j$(nproc)
 
       - name: Regression
         id: regress

--- a/src/backend/commands/graphcmds.c
+++ b/src/backend/commands/graphcmds.c
@@ -99,10 +99,10 @@ CreateGraphCommand(CreateGraphStmt *stmt, const char *queryString,
 
 	if (stmt->kind & CGSK_ELABEL)
 	{
-		/* Create ag_ege table */
+		/* Create ag_edge table */
 		createELabelStmt = makeDefaultCreateAGLabelStmt(stmt->graphname,
 														LABEL_EDGE, stmt_location);
-		createVLabelStmt->only_base = (stmt->kind == CGSK_ELABEL);
+		createELabelStmt->only_base = (stmt->kind == CGSK_ELABEL);
 		SimpleProcessUtility((Node *) createELabelStmt, queryString, stmt_location,
 							 stmt_len);
 		CommandCounterIncrement();

--- a/src/backend/executor/execCypherDelete.c
+++ b/src/backend/executor/execCypherDelete.c
@@ -153,6 +153,7 @@ ExecDeleteEdgeOrVertex(ModifyGraphState *mgstate, ResultRelInfo *resultRelInfo,
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
 					 errmsg("modifying the same element more than once cannot happen")));
+			break;
 		case TM_Ok:
 			break;
 
@@ -161,8 +162,10 @@ ExecDeleteEdgeOrVertex(ModifyGraphState *mgstate, ResultRelInfo *resultRelInfo,
 			ereport(ERROR,
 					(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
 					 errmsg("could not serialize access due to concurrent update")));
+			break;
 		default:
 			elog(ERROR, "unrecognized heap_update status: %u", result);
+			break;
 	}
 
 	/* AFTER ROW DELETE Triggers */

--- a/src/backend/executor/execCypherMerge.c
+++ b/src/backend/executor/execCypherMerge.c
@@ -90,9 +90,10 @@ createMergePath(ModifyGraphState *mgstate, GraphPath *path,
 	Graphid		prevvid = 0;
 	GraphEdge  *gedge = NULL;
 
+	pathlen = list_length(path->chain);
+
 	if (out)
 	{
-		pathlen = list_length(path->chain);
 		Assert(pathlen % 2 == 1);
 
 		vertices = makeDatumArray((pathlen / 2) + 1);

--- a/src/backend/executor/execCypherSet.c
+++ b/src/backend/executor/execCypherSet.c
@@ -602,6 +602,7 @@ LegacyUpdateElemProp(ModifyGraphState *mgstate, Oid elemtype, Datum gid,
 					 errmsg("graph element(%hu," UINT64_FORMAT ") has been SET multiple times",
 							GraphidGetLabid(DatumGetGraphid(gid)),
 							GraphidGetLocid(DatumGetGraphid(gid)))));
+			break;
 		case TM_Ok:
 			break;
 		case TM_Updated:
@@ -609,8 +610,10 @@ LegacyUpdateElemProp(ModifyGraphState *mgstate, Oid elemtype, Datum gid,
 			ereport(ERROR,
 					(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
 					 errmsg("could not serialize access due to concurrent update")));
+			break;
 		default:
 			elog(ERROR, "unrecognized heap_update status: %u", result);
+			break;
 	}
 
 	if (resultRelInfo->ri_NumIndices > 0 && update_indexes)

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -25,11 +25,6 @@
 #include "utils/lsyscache.h"
 #include "nodes/graphnodes.h"
 
-/* Ignore deprecated-non-prototype warnings. */
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-non-prototype"
-
-
 static bool expression_returns_set_walker(Node *node, void *context);
 static int	leftmostLoc(int loc1, int loc2);
 static bool fix_opfuncids_walker(Node *node, void *context);
@@ -5076,5 +5071,3 @@ raw_expression_tree_mutator(Node *node,
 	/* can't get here, but keep compiler happy */
 	return NULL;
 }
-
-#pragma clang diagnostic pop

--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -5154,7 +5154,7 @@ extractVerticesExpr(ParseState *pstate, List *exprlist, ParseExprKind exprKind)
 
 			case GRAPHPATHOID:
 				elem = getExprField((Expr *) elem, AG_PATH_VERTICES);
-				/* no break */
+				/* fall through */
 			case VERTEXOID:
 				{
 					GraphDelElem *gde = makeNode(GraphDelElem);
@@ -5194,7 +5194,7 @@ extractEdgesExpr(ParseState *pstate, List *exprlist, ParseExprKind exprKind)
 
 			case GRAPHPATHOID:
 				elem = getExprField((Expr *) elem, AG_PATH_EDGES);
-				/* no break */
+				/* fall through */
 			case EDGEOID:
 				{
 					GraphDelElem *gde = makeNode(GraphDelElem);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -2123,7 +2123,7 @@ ExecDropStmt(DropStmt *stmt, bool isTopLevel)
 								 errmsg("improper property index name")));
 				}
 			}
-			/* fail through */
+			/* fall through */
 
 		case OBJECT_INDEX:
 			if (stmt->concurrent)

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -10741,12 +10741,13 @@ get_const_expr(Const *constval, deparse_context *context, int showtype)
 							break;
 						default:
 							elog(ERROR, "unknown jsonb iterator token type");
+							break;
 					}
 				}
 
 				break;
 			}
-
+			/* fall through */
 		default:
 			simple_quote_literal(buf, extval);
 			break;


### PR DESCRIPTION
- Added fall through comments where expected to silence compiler warnings
- Added missing break statements in switch cases
- Fixed unused variable warnings
- Additionally, this PR removes silent flag from the regression test workflow to see the build logs